### PR TITLE
Add missing http header and query string in the forwarded request

### DIFF
--- a/queue-worker/main.go
+++ b/queue-worker/main.go
@@ -90,10 +90,14 @@ func main() {
 		req := queue.Request{}
 		json.Unmarshal(msg.Data, &req)
 		fmt.Printf("Request for %s.\n", req.Function)
-		urlFunction := fmt.Sprintf("http://%s%s:8080/", req.Function, functionSuffix)
+		functionURL := fmt.Sprintf("http://%s%s:8080/?%s", req.Function, functionSuffix, req.QueryString)
 
-		request, err := http.NewRequest("POST", urlFunction, bytes.NewReader(req.Body))
+		request, err := http.NewRequest("POST", functionURL, bytes.NewReader(req.Body))
 		defer request.Body.Close()
+
+		for k, v := range req.Header {
+			request.Header[k] = v
+		}
 
 		res, err := client.Do(request)
 		var status int


### PR DESCRIPTION
Signed-off-by: Sean <wonderxboy@gmail.com>

Add request headers and query string to the forwarded request.

#How it was tested

1. using the following C# function

```CSharp
public void Handle(string input) {
    var queryString = Environment.GetEnvironmentVariable("Http_Query");
    var forwardHeader = Environment.GetEnvironmentVariable("Http_X_Forwarded_By");

    Console.WriteLine(
        string.Format("Request query string: '{0}' , forward header: '{1}'",
        queryString,
        forwardHeader));
}  
```
2. Screenshot below, before  and after the fix

<img width="1145" alt="screen shot 2017-11-08 at 11 32 51 pm" src="https://user-images.githubusercontent.com/1066475/32557598-985c8e6e-c4dd-11e7-8ba4-2ac7f4c9c8b0.png">
