### PR TITLE
Honour req.Method invoking function

### DIFF
--- a/queue-worker/main.go
+++ b/queue-worker/main.go
@@ -92,7 +92,7 @@ func main() {
 		fmt.Printf("Request for %s.\n", req.Function)
 		urlFunction := fmt.Sprintf("http://%s%s:8080/", req.Function, functionSuffix)
 
-		request, err := http.NewRequest("POST", urlFunction, bytes.NewReader(req.Body))
+		request, err := http.NewRequest(req.Method, urlFunction, bytes.NewReader(req.Body))
 		defer request.Body.Close()
 
 		res, err := client.Do(request)


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Expected Behaviour
<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->
If you're invoking a function asynchronously via GET that method should be set in the Http_Method envvar.

## Current Behaviour
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->
Currently the watchdog invocation method is hardcoded to POST.

## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
<!--- or ideas how to implement the addition or change -->
We pass the original request method to the queue worker, this PR uses that value to invoke the function.

## Steps to Reproduce (for bugs)
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->
1. Deploy an async gateway (assumes openfaas/faas#377 is accepted/merged)
2. Attempt to invoke an async function via GET
3. Http_Method should reflect the GET method
4. Attempt to invoke an async function via POST
5. Http_Method should reflect the POST method

## Context
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->
Trying to invoke an async function via GET.

## Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* Docker version `docker version` (e.g. Docker 17.0.05 ):
17.09.0-ce

* Are you using Docker Swarm or Kubernetes (FaaS-netes)?
Swarm

* Operating System and version (e.g. Linux, Windows, MacOS):
OSX

* Link to your project or a code example to reproduce issue:
n/a