### PR TITLE
NATS streaming reconnect handlers for gateway and queue-workers

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -13,7 +13,8 @@ import (
 
 // NatsQueue queue for work
 type NatsQueue struct {
-	nc stan.Conn
+	nc       stan.Conn
+	natsConn *nats.Conn
 }
 
 // CreateNatsQueue ready for asynchronous processing
@@ -37,6 +38,7 @@ func CreateNatsQueue(address string, port int) (*NatsQueue, error) {
 		return nil, err
 	}
 	queue1.nc = nc
+	queue1.natsConn = natsConn
 
 	return &queue1, err
 }
@@ -66,5 +68,6 @@ func (q *NatsQueue) reconnectClient(clientID, clusterID, natsURL string) nats.Co
 			return
 		}
 		q.nc = nc
+		q.natsConn = c
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -16,8 +16,6 @@ type NatsQueue struct {
 	nc stan.Conn
 }
 
-var natsConn *nats.Conn
-
 // CreateNatsQueue ready for asynchronous processing
 func CreateNatsQueue(address string, port int) (*NatsQueue, error) {
 	queue1 := NatsQueue{}
@@ -29,7 +27,7 @@ func CreateNatsQueue(address string, port int) (*NatsQueue, error) {
 	clientID := "faas-publisher-" + val
 	clusterID := "faas-cluster"
 
-	natsConn, err = nats.Connect(natsURL, nats.ReconnectHandler(queue1.reconnectClient(clientID, clusterID, natsURL)))
+	natsConn, err := nats.Connect(natsURL, nats.ReconnectHandler(queue1.reconnectClient(clientID, clusterID, natsURL)))
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +60,6 @@ func (q *NatsQueue) Queue(req *queue.Request) error {
 func (q *NatsQueue) reconnectClient(clientID, clusterID, natsURL string) nats.ConnHandler {
 	return func(c *nats.Conn) {
 		q.nc.Close()
-		c.SetReconnectHandler(q.reconnectClient(clientID, clusterID, natsURL))
 		nc, err := stan.Connect(clusterID, clientID, stan.NatsConn(c))
 		if err != nil {
 			log.Printf("Failed to reconnect to NATS stream\n%v", err)

--- a/queue-worker/main.go
+++ b/queue-worker/main.go
@@ -213,7 +213,7 @@ func main() {
 	var sc stan.Conn
 	reconnectHandler = func(nc *nats.Conn) {
 		sc.Close()
-
+		log.Println("NATS Reconnect detected, rejoining NATS Stream...\n")
 		sc, err = stan.Connect(clusterID, clientID, stan.NatsConn(nc))
 		if err != nil {
 			log.Fatalf("Can't connect: %v\n", err)


### PR DESCRIPTION
Signed-off-by: Vincent Smith <vosmith08@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
This PR adds support for the NATS streaming clients to reconnect to the NATS Streaming servers when a NATS connection is reset.

## Description
<!--- Describe your changes in detail -->
The handler for the gateway and the queue-worker both have wrappers around their NATS connections to handle an `onReconnect` event from the underlying NATS connection.  The gateway re-connects to the NATS Streaming server using the same client and cluster IDs.  The queue-worker re-connects and resubscribes to the `faas-request` topic.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, when a NATS connection was reset, the clients would not be able to communicate with the NATS streaming server. This is due to the NATS streaming server running in in-memory mode [as detailed in this issue](https://github.com/nats-io/nats-streaming-server/issues/150).

<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

openfaas/faas#579

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the OpenFaaS helm chart, I deployed an OpenFaaS stack on a Kubernetes cluster running Kubernetes 1.8.8.  I deployed a simple echo function using faas-cli.  While tailing the logs of the gateway and the queue-worker pods, I invoked the echo function with --async and watched the logs show the messages being passed successfully.  I killed the NATS container and waited for it to start up again.  I invoked the function with --async again and waited for the publish ack timeout to occur.

Using a modified helm chart and Docker images, I deployed an OpenFaaS stack with the changes from this PR on a the same K8s cluster.  I deployed a simple echo function using faas-cli.  While tailing the logs of the gateway and the queue-worker pods, I invoked the echo function with --async and watched the messages being passed successfully.  I killed the NATS container and waited for it to start up again.   Log message is printed by the queue worker on successful reconnection.  I  invoked the function again and saw the messages being successfully passed.

I also ran the function in a loop, invoking the call every 1 second.  When killing the NATS container, 1 publish ack timeout occurs and the subsequent messages are published successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
