### PR TITLE
Remove unsupported characters from client id

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/openfaas/faas/gateway/queue"
+	"regexp"
 )
 
 // NatsQueue queue for work
@@ -22,9 +23,11 @@ type NatsConfig interface {
 type DefaultNatsConfig struct {
 }
 
+var supportedCharacters, _ = regexp.Compile("[^a-zA-Z0-9-_]+")
+
 func (DefaultNatsConfig) GetClientID() string {
 	val, _ := os.Hostname()
-	return "faas-publisher-" + val
+	return getClientId(val)
 }
 
 // CreateNatsQueue ready for asynchronous processing
@@ -57,4 +60,8 @@ func (q *NatsQueue) Queue(req *queue.Request) error {
 	err = q.nc.Publish("faas-request", out)
 
 	return err
+}
+
+func getClientId(hostname string) string {
+	return "faas-publisher-" + supportedCharacters.ReplaceAllString(hostname, "_")
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -17,3 +17,23 @@ func Test_GetClientID_ContainsHostname(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestCreateClientId(t *testing.T) {
+	clientId := getClientId("computer-a")
+	expected := "faas-publisher-computer-a"
+	if clientId != expected {
+		t.Logf("Expected client id `%s` actual `%s`\n", expected, clientId)
+		t.Fail()
+	}
+}
+
+func TestCreateClientIdWhenHostHasUnsupportedCharacters(t *testing.T) {
+	clientId := getClientId("computer-a.acme.com")
+	expected := "faas-publisher-computer-a_acme_com"
+	if clientId != expected {
+		t.Logf("Expected client id `%s` actual `%s`\n", expected, clientId)
+		t.Fail()
+	}
+}
+
+


### PR DESCRIPTION
Fixes bug when running this package on an ecs instance.
ECS hostname contains `.` which is not supported by nats.

Signed-off-by: Edward Wilde <ewilde@gmail.com>


## Description
When running this package on Amazon ECS you get the following error:

`stan: invalid clientID: only alphanumeric and `-` or `_` characters allowed`.

This is because the ECS host name contains periods `.` i.e. `ip-10-0-1-140.eu-west-1.compute.internal`


## How Has This Been Tested?
This has been tested on ECS in a custom build of `gateway` and now starts properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [? ] I have added tests to cover my changes. Didn't see any tests in the project, happy to add if that's what's wanted
- [ ] All new and existing tests passed.
