### PR TITLE
Check if res is nil before copy Header

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,7 +246,9 @@ func postResult(client *http.Client, functionRes *http.Response, result []byte, 
 
 	request, err := http.NewRequest(http.MethodPost, callbackURL, reader)
 
-	copyHeaders(request.Header, &functionRes.Header)
+	if functionRes != nil {
+		copyHeaders(request.Header, &functionRes.Header)
+	}
 
 	res, err := client.Do(request)
 


### PR DESCRIPTION
If res is nil with err, the container would be killed by SIGSEGV. Runtime error: invalid memory address or nil pointer dereference

## Description
Check the src is not nil before copying Header

## Motivation and Context
When adding a new feature according to our need, I found this minor issue.

## How Has This Been Tested?
I tested this code by hardcode the functionRes to nil when calling postResult.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
