### PR TITLE
Populate the error information when post request got errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,14 @@ func main() {
 			if req.CallbackURL != nil {
 				log.Printf("Callback to: %s\n", req.CallbackURL.String())
 
+				jsonResponse := fmt.Sprintf(`{"status_code": %d, "content": "%s", "url": "%s"}`, status, err.Error(), functionURL)
+				functionResult = []byte(jsonResponse)
+
+				if res == nil {
+					res = & http.Response{Header: make(http.Header, 0)}
+					copyHeaders(res.Header, &req.Header)
+				}
+
 				resultStatusCode, resultErr := postResult(&client, res, functionResult, req.CallbackURL.String())
 				if resultErr != nil {
 					log.Println(resultErr)


### PR DESCRIPTION
1. Populate the error informations in response body when transmitting back execution results to the callback url when there are errors.
2. Add information for which function caused the errors.

Signed-off-by: yubol <yubol@splunk.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Populate the error informations in response body when transmitting back execution results to the callback url when there are errors.
2. Add information for which function caused the errors.

## Motivation and Context
1. When there is error in `http.NewRequest(http.MethodPost, functionURL, bytes.NewReader(req.Body))`, the functionResult is empty, thus the client has noway to know what happens, and could not execute any post-error-handling process.
2. Also it is possible that some functions would share the same `X-Callback-Url` and they are intended to do some parsing job for the response body instead of depending on different callback url. However when error happens, the response body is empty, the client has no way to know which function caused the error.

## How Has This Been Tested?
Hard code an err and check received response from the client side's logs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
