### PR TITLE
Use ReadConfig object for env config, add write_debug for queue worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /go/src/github.com/openfaas/nats-queue-worker
 COPY vendor     vendor
 COPY handler    handler
 COPY main.go  .
+COPY readconfig.go .
+COPY readconfig_test.go .
 
-RUN go test -v ./handler/
+RUN go test -v ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:3.7

--- a/readconfig.go
+++ b/readconfig.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+)
+
+// ReadConfig constitutes config from env variables
+type ReadConfig struct {
+}
+
+func (ReadConfig) Read() QueueWorkerConfig {
+	cfg := QueueWorkerConfig{}
+
+	if val, exists := os.LookupEnv("faas_nats_address"); exists {
+		cfg.NatsAddress = val
+	} else {
+		cfg.NatsAddress = "nats"
+	}
+
+	if val, exists := os.LookupEnv("faas_gateway_address"); exists {
+		cfg.GatewayAddress = val
+	} else {
+		cfg.GatewayAddress = "gateway"
+	}
+
+	if val, exists := os.LookupEnv("faas_function_suffix"); exists {
+		cfg.FunctionSuffix = val
+	}
+
+	if val, exists := os.LookupEnv("faas_print_body"); exists {
+		if val == "1" || val == "true" {
+			cfg.DebugPrintBody = true
+		} else {
+			cfg.DebugPrintBody = false
+		}
+	}
+
+	if val, exists := os.LookupEnv("write_debug"); exists {
+		if val == "1" || val == "true" {
+			cfg.WriteDebug = true
+		} else {
+			cfg.WriteDebug = false
+		}
+	}
+
+	return cfg
+}
+
+type QueueWorkerConfig struct {
+	NatsAddress    string
+	GatewayAddress string
+	FunctionSuffix string
+	DebugPrintBody bool
+	WriteDebug     bool
+}

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_ReadConfig(t *testing.T) {
+
+	readConfig := ReadConfig{}
+
+	os.Setenv("faas_nats_address", "test_nats")
+	os.Setenv("faas_gateway_address", "test_gatewayaddr")
+	os.Setenv("faas_function_suffix", "test_suffix")
+	os.Setenv("faas_print_body", "true")
+	os.Setenv("write_debug", "true")
+
+	config := readConfig.Read()
+
+	expected := "test_nats"
+	if config.NatsAddress != expected {
+		t.Logf("Expected NatsAddress `%s` actual `%s`\n", expected, config.NatsAddress)
+		t.Fail()
+	}
+
+	expected = "test_gatewayaddr"
+	if config.GatewayAddress != expected {
+		t.Logf("Expected GatewayAddress `%s` actual `%s`\n", expected, config.GatewayAddress)
+		t.Fail()
+	}
+
+	expected = "test_suffix"
+	if config.FunctionSuffix != expected {
+		t.Logf("Expected FunctionSuffix `%s` actual `%s`\n", expected, config.FunctionSuffix)
+		t.Fail()
+	}
+
+	if config.DebugPrintBody != true {
+		t.Logf("Expected DebugPrintBody `%v` actual `%v`\n", true, config.DebugPrintBody)
+		t.Fail()
+	}
+
+	if config.WriteDebug != true {
+		t.Logf("Expected WriteDebug `%v` actual `%v`\n", true, config.WriteDebug)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Include write_debug env variable option, default false

Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
This change adds a similar Config object that the `faas` repo features ([see here](https://github.com/openfaas/faas/blob/d3d320dc33262fdc63c00440f8b800219849ac3d/gateway/types/readconfig.go#L56)). Env variables are parsed into a `ReadConfig` object, which is later read from in the `main` function.

## Description
<!--- Describe your changes in detail -->
In addition, the `write_debug` option is now available, which is false by default. If you set it to `true` or `1`, you will see the output of the asynchronously invoked function in the logs for the `func_queue-worker` container.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/nats-queue-worker/issues/11

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test file `readconfig_test.go` was added at the root of the repo.

Execution of these tests was added to the `Dockerfile`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
