### PR TITLE
Move queue-worker from functions/ to openfaas/ ns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success:
     - if [ ! -z "$TRAVIS_TAG" ] ; then
     
         if [ -z $DOCKER_NS ] ; then
-          export DOCKER_NS=functions;
+          export DOCKER_NS=openfaas;
           fi
 
         docker tag $DOCKER_NS/queue-worker:latest-dev $DOCKER_NS/queue-worker:$TRAVIS_TAG;

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 TAG?=latest
 
 build:
-	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t functions/queue-worker:$(TAG) .
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/queue-worker:$(TAG) .
 
 push:
-	docker push functions/queue-worker:$(TAG)
+	docker push openfaas/queue-worker:$(TAG)
 
 all: build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a queue-worker to enable asynchronous processing of function requests.
 
 * [Read more in the async guide](https://github.com/openfaas/faas/blob/master/guide/asynchronous.md)
 
-Hub image: [functions/queue-worker](https://hub.docker.com/r/functions/queue-worker/)
+Hub image: [openfaas/queue-worker](https://hub.docker.com/r/openfaas/queue-worker/)
 
 License: MIT
 

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,6 @@ if [ $1 ] ; then
   eTAG=$1
 fi
 
-echo Building functions/queue-worker:$eTAG
+echo Building openfaas/queue-worker:$eTAG
 
-docker build --build-arg http_proxy=$http_proxy -t functions/queue-worker:$eTAG .
+docker build --build-arg http_proxy=$http_proxy -t openfaas/queue-worker:$eTAG .


### PR DESCRIPTION
This moves queue-worker to a better name for images and also gives
free image-scanning  and  gives  more  confidence  to  users  that
components  ship  regularly  and  makes  any  vulnerabilities  in
components clear

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

[#741](https://github.com/openfaas/faas/issues/741)

## How Has This Been Tested?

Tested with local build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.