### PR TITLE
Update publisher to re-connect

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"log"
 
+	nats "github.com/nats-io/go-nats"
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/openfaas/faas/gateway/queue"
 )
 
 // NatsQueue queue for work
 type NatsQueue struct {
-	nc        stan.Conn
+	stanConn  stan.Conn
+	natsConn  *nats.Conn
 	ClientID  string
 	ClusterID string
 	NATSURL   string
@@ -27,20 +29,32 @@ func CreateNatsQueue(address string, port int, clientConfig NatsConfig) (*NatsQu
 	clientID := clientConfig.GetClientID()
 	clusterID := "faas-cluster"
 
-	nc, err := stan.Connect(clusterID, clientID, stan.NatsURL(natsURL))
 	queue1 := NatsQueue{
-		nc:        nc,
 		ClientID:  clientID,
 		ClusterID: clusterID,
 		NATSURL:   natsURL,
 		Topic:     "faas-request",
 	}
 
+	natsConn, err := nats.Connect(natsURL, nats.ReconnectHandler(queue1.reconnectClient(clientID, clusterID, natsURL)))
+	if err != nil {
+		return nil, err
+	}
+
+	stanConn, err := stan.Connect(clusterID, clientID, stan.NatsConn(natsConn))
+	if err != nil {
+		return nil, err
+	}
+
+	queue1.natsConn = natsConn
+	queue1.stanConn = stanConn
+
 	return &queue1, err
 }
 
 // Queue request for processing
 func (q *NatsQueue) Queue(req *queue.Request) error {
+
 	var err error
 
 	fmt.Printf("NatsQueue - submitting request: %s.\n", req.Function)
@@ -50,7 +64,26 @@ func (q *NatsQueue) Queue(req *queue.Request) error {
 		log.Println(err)
 	}
 
-	err = q.nc.Publish(q.Topic, out)
+	err = q.stanConn.Publish(q.Topic, out)
 
 	return err
+}
+
+func (q *NatsQueue) reconnectClient(clientID, clusterID, natsURL string) nats.ConnHandler {
+	return func(c *nats.Conn) {
+		oldConn := q.stanConn
+
+		defer oldConn.Close()
+
+		stanConn, err := stan.Connect(clusterID, clientID, stan.NatsConn(c))
+		if err != nil {
+			log.Printf("Failed to reconnect to NATS\n%v", err)
+			return
+		} else {
+			log.Printf("Reconnected to NATS\n")
+		}
+
+		q.stanConn = stanConn
+		q.natsConn = c
+	}
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

The publisher will now re-connect when NATS Streaming becomes
unavailable. Tested within the gateway code on Docker Swarm.

Thanks to @vosmith for initiating this work.

## Motivation and Context

#17 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In the gateway, by scaling NATS Streaming to zero replicas and back again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@vosmith @kozlovic @stefanprodan how is this looking?

I want to move the work started by @vosmith forward gradually. I realize that an in-memory restart is not ideal, so we're also looking to provide a configuration with some form of "ft" or PV.