### PR TITLE
Remove HTTP Host header override

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,6 @@ func main() {
 		request, err := http.NewRequest(http.MethodPost, functionURL, bytes.NewReader(req.Body))
 		defer request.Body.Close()
 
-		request.Host = req.Host
 		copyHeaders(request.Header, &req.Header)
 
 		res, err := client.Do(request)


### PR DESCRIPTION
## Description

Fix for Istio integration https://github.com/openfaas/faas/issues/851

The gateway will create or forward the X-Forwarded-Host header that contains the original host, no need to override the http client Host. https://github.com/openfaas/faas/pull/861

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested ok GKE with the Helm chart from https://github.com/openfaas/faas-netes/pull/279 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
