### PR TITLE
Remove warning message for basic auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -26,3 +26,18 @@ func AddBasicAuth(req *http.Request) error {
 	}
 	return nil
 }
+
+//LoadCredentials load credentials from dis
+func LoadCredentials() (*auth.BasicAuthCredentials, error) {
+	reader := auth.ReadBasicAuthFromDisk{}
+
+	if len(os.Getenv("secret_mount_path")) > 0 {
+		reader.SecretMountPath = os.Getenv("secret_mount_path")
+	}
+
+	credentials, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to read basic auth: %s", err.Error())
+	}
+	return credentials, nil
+}

--- a/auth.go
+++ b/auth.go
@@ -10,17 +10,19 @@ import (
 
 //AddBasicAuth to a request by reading secrets
 func AddBasicAuth(req *http.Request) error {
-	reader := auth.ReadBasicAuthFromDisk{}
+	if os.Getenv("basic_auth") == "true" {
+		reader := auth.ReadBasicAuthFromDisk{}
 
-	if len(os.Getenv("secret_mount_path")) > 0 {
-		reader.SecretMountPath = os.Getenv("secret_mount_path")
+		if len(os.Getenv("secret_mount_path")) > 0 {
+			reader.SecretMountPath = os.Getenv("secret_mount_path")
+		}
+
+		credentials, err := reader.Read()
+		if err != nil {
+			return fmt.Errorf("Unable to read basic auth: %s", err.Error())
+		}
+
+		req.SetBasicAuth(credentials.User, credentials.Password)
 	}
-
-	credentials, err := reader.Read()
-	if err != nil {
-		return fmt.Errorf("Unable to read basic auth: %s", err.Error())
-	}
-
-	req.SetBasicAuth(credentials.User, credentials.Password)
 	return nil
 }


### PR DESCRIPTION
This commit removes warning message when basic auth is not enabled and
basic auth secrets are not passed.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on local docker swarm cluster

### Basic auth disabled for gatway and no secrets passed to queue worker.
```
func_queue-worker.1.eh3w76xgdp0f@linuxkit-025000000001    | [#1] Received on [faas-request]: 'sequence:1 subject:"faas-request" data:"{\"Header\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"6\"],\"Content-Type\":[\"text/plain\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Call-Id\":[\"9edf1de4-f443-4271-80d6-e77addf4ff7d\"],\"X-Start-Time\":[\"1537816599406541631\"]},\"Host\":\"localhost:8080\",\"Body\":\"Vml2ZWsK\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"figlet\",\"CallbackUrl\":null}" timestamp:1537816599407531060 '
func_queue-worker.1.eh3w76xgdp0f@linuxkit-025000000001    | Request for figlet.
func_queue-worker.1.eh3w76xgdp0f@linuxkit-025000000001    | Wrote 162 Bytes
func_queue-worker.1.eh3w76xgdp0f@linuxkit-025000000001    | 200 OK
func_queue-worker.1.eh3w76xgdp0f@linuxkit-025000000001    | Posting report - 200
```

### Basic auth disabled and secrets passed to queue worker
```
func_queue-worker.1.ohwotv6new4t@linuxkit-025000000001    | [#1] Received on [faas-request]: 'sequence:2 subject:"faas-request" data:"{\"Header\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"6\"],\"Content-Type\":[\"text/plain\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Call-Id\":[\"5a2cb4a5-3cc0-4e52-92ad-f79b380dce10\"],\"X-Start-Time\":[\"1537817181131051735\"]},\"Host\":\"localhost:8080\",\"Body\":\"Vml2ZWsK\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"figlet\",\"CallbackUrl\":null}" timestamp:1537817181131629704 '
func_queue-worker.1.ohwotv6new4t@linuxkit-025000000001    | Request for figlet.
func_queue-worker.1.ohwotv6new4t@linuxkit-025000000001    | Wrote 162 Bytes
func_queue-worker.1.ohwotv6new4t@linuxkit-025000000001    | 200 OK
func_queue-worker.1.ohwotv6new4t@linuxkit-025000000001    | Posting report - 200
```

### Basic auth enabled and secrets passed to queue worker
```
func_queue-worker.1.rugjmed1riei@linuxkit-025000000001    | [#1] Received on [faas-request]: 'sequence:3 subject:"faas-request" data:"{\"Header\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"6\"],\"Content-Type\":[\"text/plain\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Call-Id\":[\"9bf3ced2-265f-4728-b9ab-8ce76be481b9\"],\"X-Start-Time\":[\"1537818186645166535\"]},\"Host\":\"localhost:8080\",\"Body\":\"Vml2ZWsK\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"figlet\",\"CallbackUrl\":null}" timestamp:1537818186645611229 '
func_queue-worker.1.rugjmed1riei@linuxkit-025000000001    | Request for figlet.
func_queue-worker.1.rugjmed1riei@linuxkit-025000000001    | Wrote 162 Bytes
func_queue-worker.1.rugjmed1riei@linuxkit-025000000001    | 200 OK
func_queue-worker.1.rugjmed1riei@linuxkit-025000000001    | Posting report - 200
```
### Basic auth enabled and no secrets passed to queue worker
```
func_queue-worker.1.uvhbvqox0and@linuxkit-025000000001    | [#1] Received on [faas-request]: 'sequence:4 subject:"faas-request" data:"{\"Header\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"6\"],\"Content-Type\":[\"text/plain\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Call-Id\":[\"5d6b3040-543f-4cf3-9803-1ef4e15b03bb\"],\"X-Start-Time\":[\"1537818785440410448\"]},\"Host\":\"localhost:8080\",\"Body\":\"Vml2ZWsK\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"figlet\",\"CallbackUrl\":null}" timestamp:1537818785440898243 '
func_queue-worker.1.uvhbvqox0and@linuxkit-025000000001    | Request for figlet.
func_queue-worker.1.uvhbvqox0and@linuxkit-025000000001    | Wrote 162 Bytes
func_queue-worker.1.uvhbvqox0and@linuxkit-025000000001    | 200 OK
func_queue-worker.1.uvhbvqox0and@linuxkit-025000000001    | Error with AddBasicAuth : Unable to read basic auth: unable to load /run/secrets/basic-auth-user
func_queue-worker.1.uvhbvqox0and@linuxkit-025000000001    | Posting report - 401
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
