### PR TITLE
Remove invalid hostname characters from nats client id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /go/src/github.com/openfaas/nats-queue-worker
 
 COPY vendor     vendor
 COPY handler    handler
+COPY nats       nats
 COPY main.go  .
 COPY readconfig.go .
 COPY readconfig_test.go .

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -3,6 +3,7 @@ WORKDIR /go/src/github.com/openfaas/nats-queue-worker
 
 COPY vendor     vendor
 COPY handler    handler
+COPY nats       nats
 COPY main.go  .
 COPY readconfig.go .
 COPY readconfig_test.go .

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"github.com/openfaas/nats-queue-worker/nats"
 	"os"
 	"strings"
 	"testing"
@@ -12,7 +13,7 @@ func Test_GetClientID_ContainsHostname(t *testing.T) {
 	val := c.GetClientID()
 
 	hostname, _ := os.Hostname()
-	encodedHostname := supportedCharacters.ReplaceAllString(hostname, "_")
+	encodedHostname := nats.GetClientID(hostname)
 	if !strings.HasSuffix(val, encodedHostname) {
 		t.Errorf("GetClientID should contain hostname as suffix, got: %s", val)
 		t.Fail()

--- a/handler/nats_config.go
+++ b/handler/nats_config.go
@@ -2,7 +2,8 @@ package handler
 
 import (
 	"os"
-	"regexp"
+
+	"github.com/openfaas/nats-queue-worker/nats"
 )
 
 type NatsConfig interface {
@@ -12,8 +13,6 @@ type NatsConfig interface {
 type DefaultNatsConfig struct {
 }
 
-var supportedCharacters, _ = regexp.Compile("[^a-zA-Z0-9-_]+")
-
 // GetClientID returns the ClientID assigned to this producer/consumer.
 func (DefaultNatsConfig) GetClientID() string {
 	val, _ := os.Hostname()
@@ -21,5 +20,5 @@ func (DefaultNatsConfig) GetClientID() string {
 }
 
 func getClientID(hostname string) string {
-	return "faas-publisher-" + supportedCharacters.ReplaceAllString(hostname, "_")
+	return "faas-publisher-" + nats.GetClientID(hostname)
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/openfaas/faas-provider/auth"
 	"github.com/openfaas/faas/gateway/queue"
+	"github.com/openfaas/nats-queue-worker/nats"
 )
 
 // AsyncReport is the report from a function executed on a queue worker.
@@ -51,12 +52,11 @@ func makeClient() http.Client {
 func main() {
 	readConfig := ReadConfig{}
 	config := readConfig.Read()
-
 	log.SetFlags(0)
 
 	clusterID := "faas-cluster"
 	val, _ := os.Hostname()
-	clientID := "faas-worker-" + val
+	clientID := "faas-worker-" + nats.GetClientID(val)
 
 	var durable string
 	var qgroup string
@@ -75,7 +75,7 @@ func main() {
 	client := makeClient()
 	sc, err := stan.Connect(clusterID, clientID, stan.NatsURL("nats://"+config.NatsAddress+":4222"))
 	if err != nil {
-		log.Fatalf("Can't connect: %v\n", err)
+		log.Fatalf("Can't connect to %s: %v\n", "nats://"+config.NatsAddress+":4222", err)
 	}
 
 	startOpt := stan.StartWithLastReceived()

--- a/nats/client.go
+++ b/nats/client.go
@@ -1,0 +1,8 @@
+package nats
+
+import "regexp"
+
+var supportedCharacters = regexp.MustCompile("[^a-zA-Z0-9-_]+")
+func GetClientID(value string) string {
+	return supportedCharacters.ReplaceAllString(value, "_")
+}

--- a/nats/client_test.go
+++ b/nats/client_test.go
@@ -1,0 +1,23 @@
+package nats
+
+import (
+	"testing"
+)
+
+func TestGetClientID(t *testing.T) {
+	clientID := GetClientID("computer-a")
+	want := "computer-a"
+	if clientID != want {
+		t.Logf("Want clientID: `%s`, but got: `%s`\n", want, clientID)
+		t.Fail()
+	}
+}
+
+func TestGetClientIDWhenHostHasUnsupportedCharacters(t *testing.T) {
+	clientID := GetClientID("computer-a.acme.com")
+	want := "computer-a_acme_com"
+	if clientID != want {
+		t.Logf("Want clientID: `%s`, but got: `%s`\n", want, clientID)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
## Todo

- [x] re-test


Similar to #24 running this docker image on an ecs instance.
ECS hostname contains `.` which is not supported by nats as a value for the `clientid`.


## Description
When running this docker image on Amazon ECS you get the following error:

`stan: invalid clientID: only alphanumeric and `-` or `_` characters allowed`.

This is because the ECS host name contains periods `.` i.e. `ip-10-0-1-140.eu-west-1.compute.internal`


## How Has This Been Tested?
- [x] This has been tested on ECS in a custom build of `nats-queue-worker` and now starts properly

Test output:
```
Wait for 5m0s
Listening on [faas-request], clientID=[faas-worker-ip-10-0-4-89_eu-west-1_compute_internal], qgroup=[faas] durable=[]
```
- [x] Swarm 

Test output:
```
Loading basic authentication credentials
Wait for  5m0s
Listening on [faas-request], clientID=[faas-worker-2b97ea65f696], qgroup=[faas] durable=[]
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [? ] I have added tests to cover my changes. Didn't see any tests in the project, happy to add if that's what's wanted
- [x] All new and existing tests passed.