### PR TITLE
Added reconnection logic when NATS is disconnected

### DIFF
--- a/handler/nats_config.go
+++ b/handler/nats_config.go
@@ -2,21 +2,38 @@ package handler
 
 import (
 	"os"
+	"time"
 
 	"github.com/openfaas/nats-queue-worker/nats"
 )
 
 type NatsConfig interface {
 	GetClientID() string
+	GetMaxReconnect() int
+	GetReconnectDelay() time.Duration
 }
 
 type DefaultNatsConfig struct {
+	maxReconnect   int
+	reconnectDelay time.Duration
+}
+
+func NewDefaultNatsConfig(maxReconnect int, reconnectDelay time.Duration) DefaultNatsConfig {
+	return DefaultNatsConfig{maxReconnect, reconnectDelay}
 }
 
 // GetClientID returns the ClientID assigned to this producer/consumer.
 func (DefaultNatsConfig) GetClientID() string {
 	val, _ := os.Hostname()
 	return getClientID(val)
+}
+
+func (c DefaultNatsConfig) GetMaxReconnect() int {
+	return c.maxReconnect
+}
+
+func (c DefaultNatsConfig) GetReconnectDelay() time.Duration {
+	return c.reconnectDelay
 }
 
 func getClientID(hostname string) string {


### PR DESCRIPTION
It should resolve the issue: https://github.com/openfaas/faas/issues/1031 and also resolves issues from: https://github.com/openfaas/nats-queue-worker/pull/33

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
