### PR TITLE
Implemented reconnection logic in queue-worker

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -19,7 +19,7 @@ func AddBasicAuth(req *http.Request) error {
 
 		credentials, err := reader.Read()
 		if err != nil {
-			return fmt.Errorf("Unable to read basic auth: %s", err.Error())
+			return fmt.Errorf("unable to read basic auth: %s", err.Error())
 		}
 
 		req.SetBasicAuth(credentials.User, credentials.Password)
@@ -37,7 +37,7 @@ func LoadCredentials() (*auth.BasicAuthCredentials, error) {
 
 	credentials, err := reader.Read()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to read basic auth: %s", err.Error())
+		return nil, fmt.Errorf("unable to read basic auth: %s", err.Error())
 	}
 	return credentials, nil
 }

--- a/readconfig.go
+++ b/readconfig.go
@@ -58,6 +58,26 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		}
 	}
 
+	if value, exists := os.LookupEnv("faas_max_reconnect"); exists {
+		val, err := strconv.Atoi(value)
+
+		if err != nil {
+			log.Println("converting faas_max_reconnect to int error:", err)
+		} else {
+			cfg.MaxReconnect = val
+		}
+	}
+
+	if value, exists := os.LookupEnv("faas_reconnect_delay"); exists {
+		reconnectDelayVal, durationErr := time.ParseDuration(value)
+
+		if durationErr != nil {
+			log.Println("parse env var: faas_reconnect_delay as time.Duration error:", durationErr)
+		} else {
+			cfg.ReconnectDelay = reconnectDelayVal
+		}
+	}
+
 	if val, exists := os.LookupEnv("ack_wait"); exists {
 		ackWaitVal, durationErr := time.ParseDuration(val)
 		if durationErr != nil {
@@ -78,4 +98,6 @@ type QueueWorkerConfig struct {
 	WriteDebug     bool
 	MaxInflight    int
 	AckWait        time.Duration
+	MaxReconnect   int
+	ReconnectDelay time.Duration
 }


### PR DESCRIPTION
It's the second part of: https://github.com/openfaas/nats-queue-worker/pull/49 which should resolve https://github.com/openfaas/faas/issues/1031 and #33 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Implemented reconnection logic in queue-worker
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have testd it by deploying it to my local cluster with and without
persistence store in nats (mysql) and I tried to simulate
disconnections from nats server by killing the containers with it,
and trying to async invoke functions.

Logs after I scaled nats server to zero, waited some time (few seconds), and scaled it back again:
```
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Disconnected from nats://nats:4222
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Connecting to: nats://nats:4222
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Reconnection (1/5) to nats://nats:4222 failed
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Waiting 2s before next try
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Connecting to: nats://nats:4222
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Reconnection (2/5) to nats://nats:4222 failed
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Waiting 4s before next try
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Connecting to: nats://nats:4222
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Subscribing to: faas-request at nats://nats:4222
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Wait for  5m0s
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Listening on [faas-request], clientID=[faas-worker-453efcc20e04], qgroup=[faas] durable=[]
func_queue-worker.1.ve68xbsffrfq@linuxkit-025000000001    | Reconnection (3/5) to nats://nats:4222 succeeded
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
