### PR TITLE
Merge queue-worker reconnect and fix bug in gateway reconnection logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 .DS_Store
 
 nats-queue-worker
+queue-worker
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY vendor     vendor
 COPY handler    handler
 COPY nats       nats
 COPY main.go  .
+COPY types.go .
 COPY readconfig.go .
 COPY readconfig_test.go .
 COPY auth.go .

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -5,6 +5,7 @@ COPY vendor     vendor
 COPY handler    handler
 COPY nats	nats
 COPY auth.go		.
+COPY types.go .
 COPY readconfig.go 	.
 COPY readconfig_test.go .
 COPY main.go  		.

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,6 +5,7 @@ COPY vendor     vendor
 COPY handler    handler
 COPY nats       nats
 COPY main.go  .
+COPY types.go .
 COPY readconfig.go .
 COPY readconfig_test.go .
 COPY auth.go .

--- a/auth.go
+++ b/auth.go
@@ -19,7 +19,7 @@ func AddBasicAuth(req *http.Request) error {
 
 		credentials, err := reader.Read()
 		if err != nil {
-			return fmt.Errorf("Unable to read basic auth: %s", err.Error())
+			return fmt.Errorf("unable to read basic auth: %s", err.Error())
 		}
 
 		req.SetBasicAuth(credentials.User, credentials.Password)
@@ -37,7 +37,7 @@ func LoadCredentials() (*auth.BasicAuthCredentials, error) {
 
 	credentials, err := reader.Read()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to read basic auth: %s", err.Error())
+		return nil, fmt.Errorf("unable to read basic auth: %s", err.Error())
 	}
 	return credentials, nil
 }

--- a/handler/nats_config.go
+++ b/handler/nats_config.go
@@ -25,7 +25,7 @@ func NewDefaultNATSConfig(maxReconnect int, reconnectDelay time.Duration) Defaul
 // GetClientID returns the ClientID assigned to this producer/consumer.
 func (DefaultNATSConfig) GetClientID() string {
 	val, _ := os.Hostname()
-	return getClientID(val)
+	return "faas-publisher-" + nats.GetClientID(val)
 }
 
 func (c DefaultNATSConfig) GetMaxReconnect() int {
@@ -34,8 +34,4 @@ func (c DefaultNATSConfig) GetMaxReconnect() int {
 
 func (c DefaultNATSConfig) GetReconnectDelay() time.Duration {
 	return c.reconnectDelay
-}
-
-func getClientID(hostname string) string {
-	return "faas-publisher-" + nats.GetClientID(hostname)
 }

--- a/handler/nats_config.go
+++ b/handler/nats_config.go
@@ -25,7 +25,7 @@ func NewDefaultNATSConfig(maxReconnect int, reconnectDelay time.Duration) Defaul
 // GetClientID returns the ClientID assigned to this producer/consumer.
 func (DefaultNATSConfig) GetClientID() string {
 	val, _ := os.Hostname()
-	return "faas-publisher-" + nats.GetClientID(val)
+	return getClientID(val)
 }
 
 func (c DefaultNATSConfig) GetMaxReconnect() int {
@@ -34,4 +34,8 @@ func (c DefaultNATSConfig) GetMaxReconnect() int {
 
 func (c DefaultNATSConfig) GetReconnectDelay() time.Duration {
 	return c.reconnectDelay
+}
+
+func getClientID(hostname string) string {
+	return "faas-publisher-" + nats.GetClientID(hostname)
 }

--- a/handler/nats_queue.go
+++ b/handler/nats_queue.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nats-io/go-nats-streaming"
+	stan "github.com/nats-io/go-nats-streaming"
 	"github.com/openfaas/faas/gateway/queue"
 )
 
@@ -48,6 +48,8 @@ func (q *NATSQueue) Queue(req *queue.Request) error {
 }
 
 func (q *NATSQueue) connect() error {
+	log.Printf("Connect: %s\n", q.NATSURL)
+
 	nc, err := stan.Connect(
 		q.ClusterID,
 		q.ClientID,
@@ -71,8 +73,10 @@ func (q *NATSQueue) connect() error {
 }
 
 func (q *NATSQueue) reconnect() {
+	log.Printf("Reconnect\n")
+
 	for i := 0; i < q.maxReconnect; i++ {
-		time.Sleep(time.Second * time.Duration(i) * q.reconnectDelay)
+		time.Sleep(time.Duration(i) * q.reconnectDelay)
 
 		if err := q.connect(); err == nil {
 			log.Printf("Reconnecting (%d/%d) to %s. OK\n", i+1, q.maxReconnect, q.NATSURL)

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 		ackWait:        config.AckWait,
 	}
 
-	if initErr := natsQueue.init(); initErr != nil {
+	if initErr := natsQueue.connect(); initErr != nil {
 		log.Panic(initErr)
 	}
 

--- a/nats/client.go
+++ b/nats/client.go
@@ -3,6 +3,7 @@ package nats
 import "regexp"
 
 var supportedCharacters = regexp.MustCompile("[^a-zA-Z0-9-_]+")
+
 func GetClientID(value string) string {
 	return supportedCharacters.ReplaceAllString(value, "_")
 }

--- a/readconfig.go
+++ b/readconfig.go
@@ -58,6 +58,26 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		}
 	}
 
+	if value, exists := os.LookupEnv("faas_max_reconnect"); exists {
+		val, err := strconv.Atoi(value)
+
+		if err != nil {
+			log.Println("converting faas_max_reconnect to int error:", err)
+		} else {
+			cfg.MaxReconnect = val
+		}
+	}
+
+	if value, exists := os.LookupEnv("faas_reconnect_delay"); exists {
+		reconnectDelayVal, durationErr := time.ParseDuration(value)
+
+		if durationErr != nil {
+			log.Println("parse env var: faas_reconnect_delay as time.Duration error:", durationErr)
+		} else {
+			cfg.ReconnectDelay = reconnectDelayVal
+		}
+	}
+
 	if val, exists := os.LookupEnv("ack_wait"); exists {
 		ackWaitVal, durationErr := time.ParseDuration(val)
 		if durationErr != nil {
@@ -78,4 +98,6 @@ type QueueWorkerConfig struct {
 	WriteDebug     bool
 	MaxInflight    int
 	AckWait        time.Duration
+	MaxReconnect   int
+	ReconnectDelay time.Duration
 }

--- a/readconfig.go
+++ b/readconfig.go
@@ -11,6 +11,10 @@ import (
 type ReadConfig struct {
 }
 
+const DefaultMaxReconnect = 120
+
+const DefaultReconnectDelay = time.Second * 2
+
 func (ReadConfig) Read() QueueWorkerConfig {
 	cfg := QueueWorkerConfig{
 		AckWait:     time.Second * 30,
@@ -58,6 +62,8 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		}
 	}
 
+	cfg.MaxReconnect = DefaultMaxReconnect
+
 	if value, exists := os.LookupEnv("faas_max_reconnect"); exists {
 		val, err := strconv.Atoi(value)
 
@@ -68,11 +74,14 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		}
 	}
 
+	cfg.ReconnectDelay = DefaultReconnectDelay
+
 	if value, exists := os.LookupEnv("faas_reconnect_delay"); exists {
 		reconnectDelayVal, durationErr := time.ParseDuration(value)
 
 		if durationErr != nil {
 			log.Println("parse env var: faas_reconnect_delay as time.Duration error:", durationErr)
+
 		} else {
 			cfg.ReconnectDelay = reconnectDelayVal
 		}

--- a/types.go
+++ b/types.go
@@ -40,9 +40,9 @@ type NATSQueue struct {
 
 // connect creates a subscription to NATS Streaming
 func (q *NATSQueue) connect() error {
-	log.Printf("Connecting to: %s\n", q.natsURL)
+	log.Printf("Connect: %s\n", q.natsURL)
 
-	sc, err := stan.Connect(
+	nc, err := stan.Connect(
 		q.clusterID,
 		q.clientID,
 		stan.NatsURL(q.natsURL),
@@ -59,7 +59,7 @@ func (q *NATSQueue) connect() error {
 	q.connMutex.Lock()
 	defer q.connMutex.Unlock()
 
-	q.conn = sc
+	q.conn = nc
 
 	log.Printf("Subscribing to: %s at %s\n", q.subject, q.natsURL)
 	log.Println("Wait for ", q.ackWait)
@@ -92,6 +92,8 @@ func (q *NATSQueue) connect() error {
 }
 
 func (q *NATSQueue) reconnect() {
+	log.Printf("Reconnect\n")
+
 	for i := 0; i < q.maxReconnect; i++ {
 		select {
 		case <-time.After(time.Duration(i) * q.reconnectDelay):

--- a/types.go
+++ b/types.go
@@ -38,7 +38,8 @@ type NATSQueue struct {
 	subscription   stan.Subscription
 }
 
-func (q *NATSQueue) init() error {
+// connect creates a subscription to NATS Streaming
+func (q *NATSQueue) connect() error {
 	log.Printf("Connecting to: %s\n", q.natsURL)
 
 	sc, err := stan.Connect(
@@ -94,7 +95,7 @@ func (q *NATSQueue) reconnect() {
 	for i := 0; i < q.maxReconnect; i++ {
 		select {
 		case <-time.After(time.Duration(i) * q.reconnectDelay):
-			if err := q.init(); err == nil {
+			if err := q.connect(); err == nil {
 				log.Printf("Reconnecting (%d/%d) to %s succeeded\n", i+1, q.maxReconnect, q.natsURL)
 
 				return

--- a/types.go
+++ b/types.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	stan "github.com/nats-io/go-nats-streaming"
+)
+
+// AsyncReport is the report from a function executed on a queue worker.
+type AsyncReport struct {
+	FunctionName string  `json:"name"`
+	StatusCode   int     `json:"statusCode"`
+	TimeTaken    float64 `json:"timeTaken"`
+}
+
+// NATSQueue represents a subscription to NATS Streaming
+type NATSQueue struct {
+	clusterID string
+	clientID  string
+	natsURL   string
+
+	maxReconnect   int
+	reconnectDelay time.Duration
+	conn           stan.Conn
+	connMutex      *sync.RWMutex
+	quitCh         chan struct{}
+
+	subject        string
+	qgroup         string
+	durable        string
+	ackWait        time.Duration
+	messageHandler func(*stan.Msg)
+	startOption    stan.SubscriptionOption
+	maxInFlight    stan.SubscriptionOption
+	subscription   stan.Subscription
+}
+
+func (q *NATSQueue) init() error {
+	log.Printf("Connecting to: %s\n", q.natsURL)
+
+	sc, err := stan.Connect(
+		q.clusterID,
+		q.clientID,
+		stan.NatsURL(q.natsURL),
+		stan.SetConnectionLostHandler(func(conn stan.Conn, err error) {
+			log.Printf("Disconnected from %s\n", q.natsURL)
+
+			q.reconnect()
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("can't connect to %s: %v", q.natsURL, err)
+	}
+
+	q.connMutex.Lock()
+	defer q.connMutex.Unlock()
+
+	q.conn = sc
+
+	log.Printf("Subscribing to: %s at %s\n", q.subject, q.natsURL)
+	log.Println("Wait for ", q.ackWait)
+
+	subscription, err := q.conn.QueueSubscribe(
+		q.subject,
+		q.qgroup,
+		q.messageHandler,
+		stan.DurableName(q.durable),
+		stan.AckWait(q.ackWait),
+		q.startOption,
+		q.maxInFlight,
+	)
+
+	if err != nil {
+		return fmt.Errorf("couldn't subscribe to %s at %s. Error: %v", q.subject, q.natsURL, err)
+	}
+
+	log.Printf(
+		"Listening on [%s], clientID=[%s], qgroup=[%s] durable=[%s]\n",
+		q.subject,
+		q.clientID,
+		q.qgroup,
+		q.durable,
+	)
+
+	q.subscription = subscription
+
+	return nil
+}
+
+func (q *NATSQueue) reconnect() {
+	for i := 0; i < q.maxReconnect; i++ {
+		select {
+		case <-time.After(time.Duration(i) * q.reconnectDelay):
+			if err := q.init(); err == nil {
+				log.Printf("Reconnecting (%d/%d) to %s succeeded\n", i+1, q.maxReconnect, q.natsURL)
+
+				return
+			}
+
+			nextTryIn := (time.Duration(i+1) * q.reconnectDelay).String()
+
+			log.Printf("Reconnecting (%d/%d) to %s failed\n", i+1, q.maxReconnect, q.natsURL)
+			log.Printf("Waiting %s before next try", nextTryIn)
+		case <-q.quitCh:
+			log.Println("Received signal to stop reconnecting...")
+
+			return
+		}
+	}
+
+	log.Printf("Reconnecting limit (%d) reached\n", q.maxReconnect)
+}
+
+func (q *NATSQueue) unsubscribe() error {
+	q.connMutex.Lock()
+	defer q.connMutex.Unlock()
+
+	if q.subscription != nil {
+		return fmt.Errorf("q.subscription is nil")
+	}
+
+	return q.subscription.Unsubscribe()
+}
+
+func (q *NATSQueue) closeConnection() error {
+	q.connMutex.Lock()
+	defer q.connMutex.Unlock()
+
+	if q.conn == nil {
+		return fmt.Errorf("q.conn is nil")
+	}
+
+	close(q.quitCh)
+
+	return q.conn.Close()
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Closes #52

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I deployed modified gateways and queue-workers then scaled NATS to zero, saw the reconnection messages, scaled it back then was able to send a message successfully after the recovery.

```
s/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:30 Disconnected from nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:30 Reconnect
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:30 Connect: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:30 Forwarded [GET] to /system/functions - [200] - 0.003920 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:30 Forwarded [GET] to /healthz - [200] - 0.000306 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:31 Forwarded [GET] to /system/functions - [200] - 0.010235 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:32 Forwarded [GET] to /system/functions - [200] - 0.004000 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:32 Forwarded [GET] to /healthz - [200] - 0.000276 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Disconnected from nats://nats.openfaas.svc.cluster.local:4222
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Connecting to: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:32 Reconnecting (1/60) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:33 Forwarded [GET] to /system/functions - [200] - 0.004987 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:34 Forwarded [GET] to /system/functions - [200] - 0.004020 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Reconnecting (1/120) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Waiting 2s before next try
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:34 Connect: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:35 Forwarded [GET] to /system/functions - [200] - 0.009519 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Connecting to: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:36 Reconnecting (2/60) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:36 Forwarded [GET] to /system/functions - [200] - 0.003693 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:37 Forwarded [GET] to /system/functions - [200] - 0.003020 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:38 Forwarded [GET] to /system/functions - [200] - 0.003875 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Reconnecting (2/120) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Waiting 4s before next try
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:39 Forwarded [GET] to /system/functions - [200] - 0.004449 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:40 Forwarded [GET] to /system/functions - [200] - 0.004419 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:40 Connect: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:40 Forwarded [GET] to /healthz - [200] - 0.000310 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:41 Forwarded [GET] to /system/functions - [200] - 0.004071 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:42 Forwarded [GET] to /healthz - [200] - 0.000228 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Connecting to: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:42 Reconnecting (3/60) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:42 Forwarded [GET] to /system/functions - [200] - 0.004295 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:43 Forwarded [GET] to /system/functions - [200] - 0.004441 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:44 Forwarded [GET] to /system/functions - [200] - 0.004405 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Reconnecting (3/120) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Waiting 6s before next try
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:45 Forwarded [GET] to /system/functions - [200] - 0.005420 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:46 Forwarded [GET] to /system/functions - [200] - 0.004184 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:47 Forwarded [GET] to /system/functions - [200] - 0.004441 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:48 Connect: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:48 Forwarded [GET] to /system/functions - [200] - 0.004233 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:49 Forwarded [GET] to /system/functions - [200] - 0.004060 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:50 Forwarded [GET] to /system/functions - [200] - 0.004519 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Connecting to: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:50 Reconnecting (4/60) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:50 Forwarded [GET] to /healthz - [200] - 0.000596 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:51 Forwarded [GET] to /system/functions - [200] - 0.005306 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:52 Forwarded [GET] to /healthz - [200] - 0.000256 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:52 Forwarded [GET] to /system/functions - [200] - 0.003906 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Reconnecting (4/120) to nats://nats.openfaas.svc.cluster.local:4222 failed
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Waiting 8s before next try
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:53 Forwarded [GET] to /system/functions - [200] - 0.004238 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:54 Forwarded [GET] to /system/functions - [200] - 0.004700 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:55 Forwarded [GET] to /system/functions - [200] - 0.004442 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:56 Forwarded [GET] to /system/functions - [200] - 0.010658 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:57 Forwarded [GET] to /system/functions - [200] - 0.004240 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:58 Forwarded [GET] to /system/functions - [200] - 0.004012 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:58 Connect: nats://nats.openfaas.svc.cluster.local:4222
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:58 Reconnecting (5/60) to nats://nats.openfaas.svc.cluster.local:4222. OK
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:59 Forwarded [GET] to /system/functions - [200] - 0.004833 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:29:59 Forwarded [GET] to /system/functions - [200] - 0.004211 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Connecting to: nats://nats.openfaas.svc.cluster.local:4222
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Subscribing to: faas-request at nats://nats.openfaas.svc.cluster.local:4222
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Wait for  15m0s
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Listening on [faas-request], clientID=[faas-worker-queue-worker-86d7588d56-6hr77], qgroup=[faas] durable=[]
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Reconnecting (5/120) to nats://nats.openfaas.svc.cluster.local:4222 succeeded
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:00 Forwarded [GET] to /system/functions - [200] - 0.004267 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:00 Forwarded [GET] to /healthz - [200] - 0.000257 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:01 Forwarded [GET] to /system/functions - [200] - 0.004281 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:02 Forwarded [GET] to /system/functions - [200] - 0.004128 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:02 Forwarded [GET] to /healthz - [200] - 0.000262 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:03 Forwarded [GET] to /system/functions - [200] - 0.005115 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:04 Forwarded [GET] to /system/functions - [200] - 0.004039 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:05 Forwarded [GET] to /system/functions - [200] - 0.004262 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:06 Forwarded [GET] to /system/functions - [200] - 0.010470 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:07 Forwarded [GET] to /system/functions - [200] - 0.004210 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:08 Forwarded [GET] to /system/functions - [200] - 0.004135 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:09 Forwarded [GET] to /system/functions - [200] - 0.003731 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: NatsQueue - submitting request: go-echo.
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:10 Forwarded [POST] to /async-function/go-echo - [202] - 0.001563 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: [#16] Received on [faas-request]: 'sequence:1 subject:"faas-request" data:"{\"Header\":{\"Accept\":[\"*/*\"],\"Content-Length\":[\"4\"],\"Content-Type\":[\"application/x-www-form-urlencoded\"],\"User-Agent\":[\"curl/7.54.0\"],\"X-Call-Id\":[\"94232a0d-668b-4636-a3de-9ae99a62dd84\"],\"X-Start-Time\":[\"1549992610028210333\"]},\"Host\":\"192.168.0.26:31112\",\"Body\":\"dGVzdA==\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"go-echo\",\"CallbackUrl\":null}" timestamp:1549992610036646716 '
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Request for go-echo.
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Wrote 4 Bytes
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: 200 OK
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:10 Forwarded [POST] to /system/async-report - [202] - 0.000095 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:10 Forwarded [POST] to /system/async-report - [202] - 0.000161 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Posting report - 202
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:10 Forwarded [GET] to /system/functions - [200] - 0.004862 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:10 Forwarded [GET] to /healthz - [200] - 0.000248 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:11 Forwarded [GET] to /system/functions - [200] - 0.004438 seconds
openfaas/gateway-69596ff4d7-f595q[gateway]: NatsQueue - submitting request: go-echo.
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: [#17] Received on [faas-request]: 'sequence:2 subject:"faas-request" data:"{\"Header\":{\"Accept\":[\"*/*\"],\"Content-Length\":[\"4\"],\"Content-Type\":[\"application/x-www-form-urlencoded\"],\"User-Agent\":[\"curl/7.54.0\"],\"X-Call-Id\":[\"3c1e6521-ed63-43b2-bca3-0332feef31c3\"],\"X-Start-Time\":[\"1549992612368343269\"]},\"Host\":\"192.168.0.26:31112\",\"Body\":\"dGVzdA==\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"go-echo\",\"CallbackUrl\":null}" timestamp:1549992612376733334 '
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Request for go-echo.
openfaas/gateway-69596ff4d7-f595q[gateway]: 2019/02/12 17:30:12 Forwarded [POST] to /async-function/go-echo - [202] - 0.001309 seconds
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Wrote 4 Bytes
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: 200 OK
openfaas/queue-worker-86d7588d56-6hr77[queue-worker]: Posting report - 202
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
