### PR TITLE
Pass on HTTP Path when calling functions asynchronously

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,12 +104,17 @@ func main() {
 			fmt.Println(string(req.Body))
 		}
 
+		path := "/"
+		if len(req.Path) > 0 {
+			path = req.Path
+		}
+
 		queryString := ""
 		if len(req.QueryString) > 0 {
 			queryString = fmt.Sprintf("?%s", strings.TrimLeft(req.QueryString, "?"))
 		}
 
-		functionURL := fmt.Sprintf("http://%s%s:8080/%s", req.Function, config.FunctionSuffix, queryString)
+		functionURL := fmt.Sprintf("http://%s%s:8080%s%s", req.Function, config.FunctionSuffix, path, queryString)
 
 		request, err := http.NewRequest(http.MethodPost, functionURL, bytes.NewReader(req.Body))
 		defer request.Body.Close()

--- a/vendor/github.com/openfaas/faas/gateway/queue/types.go
+++ b/vendor/github.com/openfaas/faas/gateway/queue/types.go
@@ -12,6 +12,7 @@ type Request struct {
 	Host        string
 	Body        []byte
 	Method      string
+	Path        string
 	QueryString string
 	Function    string
 	CallbackURL *url.URL `json:"CallbackUrl"`


### PR DESCRIPTION
This commit fixes faas issue https://github.com/openfaas/faas/issues/1035.
It requires the vendored faas queue.Request struct to be updated to the latest version in the faas repo.

Signed-off-by: Johan Pauwels <jpauwels@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Local (macOS) and server (Ubuntu) deployment with Docker Swarm.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
