### PR TITLE
Add gateway_invoke feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@
 
 nats-queue-worker
 queue-worker
-
+Dockerfile.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY auth.go .
 RUN go test -v ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN addgroup -S app \
   && adduser -S -g app app \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,16 +3,17 @@ WORKDIR /go/src/github.com/openfaas/nats-queue-worker
 
 COPY vendor     vendor
 COPY handler    handler
-COPY nats	nats
-COPY auth.go		.
+COPY nats       nats
+COPY main.go  .
 COPY types.go .
-COPY readconfig.go 	.
+COPY readconfig.go .
 COPY readconfig_test.go .
-COPY main.go  		.
+COPY auth.go .
+
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN addgroup -S app \
   && adduser -S -g app app \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,7 +12,7 @@ COPY auth.go .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN addgroup -S app \
   && adduser -S -g app app \

--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ Screenshots from keynote / video - find out more over at https://www.openfaas.co
 <img width="1440" alt="screen shot 2017-10-26 at 15 55 19" src="https://user-images.githubusercontent.com/6358735/32060206-047eb75c-ba66-11e7-94d3-1343ea1811db.png">
 
 <img width="1440" alt="screen shot 2017-10-26 at 15 55 06" src="https://user-images.githubusercontent.com/6358735/32060205-04545692-ba66-11e7-9e6d-b800a07b9bf5.png">
+
+### Configuration
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `gateway_invoke` | When `true` functions are invoked via the gateway, when `false` they are invoked directly | `false` |
+| `basic_auth` | When `true` basic auth is used to post any function statistics back to the gateway | `false` |
+| `write_debug` | Print verbose logs | `false` |
+| `faas_gateway_address` | Address of gateway DNS name | `gateway` |
+| `faas_function_suffix` | When `gateway_invoke` is `false`, this suffix is used to contact a function, it may correspond to a Kubernetes namespace  | `` |
+| `faas_max_reconnect` | An integer of the amount of reconnection attempts when the NATS connection is lost | `120` |
+| `faas_nats_address` | The DNS entry for NATS | `nats` |
+| `faas_reconnect_delay` | Delay between retrying to connect to NATS | `2s` |
+| `faas_print_body` | Print the body of the function invocation | `false` |

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 
 		xCallID := req.Header.Get("X-Call-Id")
 
-		fmt.Printf("Invoking: %s.\n", req.Function)
+		fmt.Printf("Invoking: %s, %d bytes.\n", req.Function, len(req.Body))
 
 		if config.DebugPrintBody {
 			fmt.Println(string(req.Body))
@@ -92,13 +92,13 @@ func main() {
 		}
 
 		start := time.Now()
-
 		request, err := http.NewRequest(http.MethodPost, functionURL, bytes.NewReader(req.Body))
-		defer request.Body.Close()
 
 		copyHeaders(request.Header, &req.Header)
 
 		res, err := client.Do(request)
+		request.Body.Close()
+
 		var status int
 		var functionResult []byte
 

--- a/main.go
+++ b/main.go
@@ -84,9 +84,9 @@ func main() {
 			queryString)
 
 		if config.GatewayInvoke {
-			functionURL = fmt.Sprintf("http://%s:8080/function/%s/%s%s",
+			functionURL = fmt.Sprintf("http://%s:8080/function/%s%s%s",
 				config.GatewayAddress,
-				req.Function,
+				strings.Trim(req.Function, "/"),
 				path,
 				queryString)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/openfaas/faas/gateway/queue"
+)
+
+func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_IncludesGWAddress(t *testing.T) {
+	config := QueueWorkerConfig{
+		FunctionSuffix: "",
+		GatewayInvoke:  true,
+		GatewayAddress: "gateway",
+	}
+	req := queue.Request{
+		Function: "function1",
+		Path:     "/",
+	}
+
+	fnURL := makeFunctionURL(&req, &config, req.Path, req.QueryString)
+	wantURL := "http://gateway:8080/function/function1/"
+	if fnURL != wantURL {
+		t.Errorf("want %s, got %s", wantURL, fnURL)
+	}
+}
+
+func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_WithQS(t *testing.T) {
+	config := QueueWorkerConfig{
+		FunctionSuffix: "",
+		GatewayInvoke:  true,
+		GatewayAddress: "gateway",
+	}
+	req := queue.Request{
+		Function:    "function1",
+		QueryString: "user=1",
+	}
+
+	fnURL := makeFunctionURL(&req, &config, req.Path, req.QueryString)
+	wantURL := "http://gateway:8080/function/function1/?user=1"
+	if fnURL != wantURL {
+		t.Errorf("want %s, got %s", wantURL, fnURL)
+	}
+}
+
+func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_WithPath(t *testing.T) {
+	config := QueueWorkerConfig{
+		FunctionSuffix: "",
+		GatewayInvoke:  true,
+		GatewayAddress: "gateway",
+	}
+	req := queue.Request{
+		Function: "function1",
+		Path:     "/resources/main.css",
+	}
+
+	fnURL := makeFunctionURL(&req, &config, req.Path, req.QueryString)
+	wantURL := "http://gateway:8080/function/function1/resources/main.css"
+	if fnURL != wantURL {
+		t.Errorf("want %s, got %s", wantURL, fnURL)
+	}
+}
+
+func Test_makeFunctionURL_DefaultPathQS_GatewayInvokeOff_UsesDirectInvocation(t *testing.T) {
+	config := QueueWorkerConfig{
+		FunctionSuffix: ".openfaas-fn",
+		GatewayInvoke:  false,
+		GatewayAddress: "gateway",
+	}
+	req := queue.Request{
+		Function: "function1",
+		Path:     "/",
+	}
+
+	fnURL := makeFunctionURL(&req, &config, req.Path, req.QueryString)
+
+	wantURL := "http://function1.openfaas-fn:8080/"
+	if fnURL != wantURL {
+		t.Errorf("want %s, got %s", wantURL, fnURL)
+	}
+}

--- a/readconfig.go
+++ b/readconfig.go
@@ -96,6 +96,18 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		}
 	}
 
+	if val, exists := os.LookupEnv("gateway_invoke"); exists {
+		if val == "1" || val == "true" {
+			cfg.GatewayInvoke = true
+		}
+	}
+
+	if val, exists := os.LookupEnv("basic_auth"); exists {
+		if val == "1" || val == "true" {
+			cfg.BasicAuth = true
+		}
+	}
+
 	return cfg
 }
 
@@ -109,4 +121,6 @@ type QueueWorkerConfig struct {
 	AckWait        time.Duration
 	MaxReconnect   int
 	ReconnectDelay time.Duration
+	GatewayInvoke  bool // GatewayInvoke invoke functions through gateway rather than directly
+	BasicAuth      bool
 }

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -6,6 +6,56 @@ import (
 	"time"
 )
 
+func Test_ReadConfig_GatewayInvokeDefault(t *testing.T) {
+
+	readConfig := ReadConfig{}
+
+	os.Setenv("gateway_invoke", "")
+	cfg := readConfig.Read()
+
+	gatewayInvokeWant := false
+	if cfg.GatewayInvoke != gatewayInvokeWant {
+		t.Errorf("gatewayInvokeWant want %v, but got %v", gatewayInvokeWant, cfg.GatewayInvoke)
+	}
+}
+
+func Test_ReadConfig_GatewayInvokeSetToTrue(t *testing.T) {
+
+	readConfig := ReadConfig{}
+
+	os.Setenv("gateway_invoke", "true")
+	cfg := readConfig.Read()
+
+	gatewayInvokeWant := true
+	if cfg.GatewayInvoke != gatewayInvokeWant {
+		t.Errorf("gatewayInvokeWant want %v, but got %v", gatewayInvokeWant, cfg.GatewayInvoke)
+	}
+}
+
+func Test_ReadConfig_BasicAuthDefaultIsFalse(t *testing.T) {
+	readConfig := ReadConfig{}
+
+	os.Setenv("basic_auth", "")
+	cfg := readConfig.Read()
+
+	want := false
+	if cfg.BasicAuth != want {
+		t.Errorf("basicAuth want %v, but got %v", want, cfg.BasicAuth)
+	}
+}
+
+func Test_ReadConfig_BasicAuthSetToTrue(t *testing.T) {
+	readConfig := ReadConfig{}
+
+	os.Setenv("basic_auth", "true")
+	cfg := readConfig.Read()
+
+	want := true
+	if cfg.BasicAuth != want {
+		t.Errorf("basicAuth want %v, but got %v", want, cfg.BasicAuth)
+	}
+}
+
 func Test_ReadConfig(t *testing.T) {
 
 	readConfig := ReadConfig{}


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

Add `gateway_invoke`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change introduces the gateway_invoke env-var which is used
to have the queue-worker invoke functions via the gateway. When
set to false the functions are invoked directly over HTTP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes: #32

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Swarm with the flag on/off. Unit tests added for
parsing new configuration option.

Options documented in README.md

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Additional configuration and options will be needed in docker-compose.yml and the helm chart.