### PR TITLE
Add GatewayPort configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Screenshots from keynote / video - find out more over at https://www.openfaas.co
 | `basic_auth` | When `true` basic auth is used to post any function statistics back to the gateway | `false` |
 | `write_debug` | Print verbose logs | `false` |
 | `faas_gateway_address` | Address of gateway DNS name | `gateway` |
+| `faas_gateway_port` | Port of gateway service | `8080` |
 | `faas_function_suffix` | When `gateway_invoke` is `false`, this suffix is used to contact a function, it may correspond to a Kubernetes namespace  | `` |
 | `faas_max_reconnect` | An integer of the amount of reconnection attempts when the NATS connection is lost | `120` |
 | `faas_nats_address` | The DNS entry for NATS | `nats` |

--- a/main.go
+++ b/main.go
@@ -30,15 +30,17 @@ func makeFunctionURL(req *queue.Request, config *QueueWorkerConfig, path, queryS
 	if len(path) > 0 {
 		pathVal = path
 	}
-	functionURL := fmt.Sprintf("http://%s%s:8080%s%s",
+	functionURL := fmt.Sprintf("http://%s%s:%s%s%s",
 		req.Function,
 		config.FunctionSuffix,
+		config.GatewayPort,
 		pathVal,
 		qs)
 
 	if config.GatewayInvoke {
-		functionURL = fmt.Sprintf("http://%s:8080/function/%s%s%s",
+		functionURL = fmt.Sprintf("http://%s:%s/function/%s%s%s",
 			config.GatewayAddress,
+			config.GatewayPort,
 			strings.Trim(req.Function, "/"),
 			pathVal,
 			qs)
@@ -137,7 +139,7 @@ func main() {
 			}
 
 			if config.GatewayInvoke == false {
-				statusCode, reportErr := postReport(&client, req.Function, status, timeTaken, config.GatewayAddress, credentials)
+				statusCode, reportErr := postReport(&client, req.Function, status, timeTaken, config.GatewayAddress, config.GatewayPort, credentials)
 				if reportErr != nil {
 					log.Println(reportErr)
 				} else {
@@ -184,7 +186,7 @@ func main() {
 		}
 
 		if config.GatewayInvoke == false {
-			statusCode, reportErr := postReport(&client, req.Function, res.StatusCode, timeTaken, config.GatewayAddress, credentials)
+			statusCode, reportErr := postReport(&client, req.Function, res.StatusCode, timeTaken, config.GatewayAddress, config.GatewayPort, credentials)
 
 			if reportErr != nil {
 				log.Println(reportErr)
@@ -310,14 +312,17 @@ func copyHeaders(destination http.Header, source *http.Header) {
 	}
 }
 
-func postReport(client *http.Client, function string, statusCode int, timeTaken float64, gatewayAddress string, credentials *auth.BasicAuthCredentials) (int, error) {
+func postReport(client *http.Client, function string, statusCode int, timeTaken float64, gatewayAddress string, gatewayPort string, credentials *auth.BasicAuthCredentials) (int, error) {
 	req := AsyncReport{
 		FunctionName: function,
 		StatusCode:   statusCode,
 		TimeTaken:    timeTaken,
 	}
 
-	targetPostback := "http://" + gatewayAddress + ":8080/system/async-report"
+	targetPostback := fmt.Sprintf("http://%s:%s/system/async-report",
+		gatewayAddress,
+		gatewayPort,
+	)
 	reqBytes, _ := json.Marshal(req)
 	request, err := http.NewRequest(http.MethodPost, targetPostback, bytes.NewReader(reqBytes))
 

--- a/main.go
+++ b/main.go
@@ -30,10 +30,9 @@ func makeFunctionURL(req *queue.Request, config *QueueWorkerConfig, path, queryS
 	if len(path) > 0 {
 		pathVal = path
 	}
-	functionURL := fmt.Sprintf("http://%s%s:%d%s%s",
+	functionURL := fmt.Sprintf("http://%s%s:8080%s%s",
 		req.Function,
 		config.FunctionSuffix,
-		config.GatewayPort,
 		pathVal,
 		qs)
 

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_IncludesGWAddress(t *testi
 		FunctionSuffix: "",
 		GatewayInvoke:  true,
 		GatewayAddress: "gateway",
+		GatewayPort: "8080",
 	}
 	req := queue.Request{
 		Function: "function1",
@@ -29,6 +30,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_WithQS(t *testing.T) {
 		FunctionSuffix: "",
 		GatewayInvoke:  true,
 		GatewayAddress: "gateway",
+		GatewayPort: "8080",
 	}
 	req := queue.Request{
 		Function:    "function1",
@@ -47,6 +49,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_WithPath(t *testing.T) {
 		FunctionSuffix: "",
 		GatewayInvoke:  true,
 		GatewayAddress: "gateway",
+		GatewayPort: "8080",
 	}
 	req := queue.Request{
 		Function: "function1",
@@ -65,6 +68,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvokeOff_UsesDirectInvocation(t 
 		FunctionSuffix: ".openfaas-fn",
 		GatewayInvoke:  false,
 		GatewayAddress: "gateway",
+		GatewayPort: "8080",
 	}
 	req := queue.Request{
 		Function: "function1",

--- a/readconfig.go
+++ b/readconfig.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -33,11 +34,18 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		cfg.GatewayAddress = "gateway"
 	}
 
-	if val, exists := os.LookupEnv("faas_gateway_port"); exists {
-		cfg.GatewayPort = val
+	if value, exists := os.LookupEnv("faas_gateway_port"); exists {
+		val, err := strconv.Atoi(value)
+		if err != nil {
+			log.Println("converting faas_gateway_port to int error:", err)
+		} else {
+			cfg.GatewayPort = val
+		}
 	} else {
-		cfg.GatewayPort = "8080"
+		cfg.GatewayPort = 8080
 	}
+
+	cfg.GatewayAddress = fmt.Sprintf("%s:%d", cfg.GatewayAddress, cfg.GatewayPort)
 
 	if val, exists := os.LookupEnv("faas_function_suffix"); exists {
 		cfg.FunctionSuffix = val
@@ -120,7 +128,7 @@ func (ReadConfig) Read() QueueWorkerConfig {
 type QueueWorkerConfig struct {
 	NatsAddress    string
 	GatewayAddress string
-	GatewayPort    string
+	GatewayPort    int
 	FunctionSuffix string
 	DebugPrintBody bool
 	WriteDebug     bool

--- a/readconfig.go
+++ b/readconfig.go
@@ -33,6 +33,12 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		cfg.GatewayAddress = "gateway"
 	}
 
+	if val, exists := os.LookupEnv("faas_gateway_port"); exists {
+		cfg.GatewayPort = val
+	} else {
+		cfg.GatewayPort = "8080"
+	}
+
 	if val, exists := os.LookupEnv("faas_function_suffix"); exists {
 		cfg.FunctionSuffix = val
 	}
@@ -114,6 +120,7 @@ func (ReadConfig) Read() QueueWorkerConfig {
 type QueueWorkerConfig struct {
 	NatsAddress    string
 	GatewayAddress string
+	GatewayPort    string
 	FunctionSuffix string
 	DebugPrintBody bool
 	WriteDebug     bool

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -62,7 +62,7 @@ func Test_ReadConfig(t *testing.T) {
 
 	os.Setenv("faas_nats_address", "test_nats")
 	os.Setenv("faas_gateway_address", "test_gatewayaddr")
-	os.Setenv("faas_gateway_port", "test_gatewayport")
+	os.Setenv("faas_gateway_port", "8080")
 	os.Setenv("faas_function_suffix", "test_suffix")
 	os.Setenv("faas_print_body", "true")
 	os.Setenv("write_debug", "true")
@@ -83,9 +83,9 @@ func Test_ReadConfig(t *testing.T) {
 		t.Fail()
 	}
 
-	expected = "test_gatewayport"
-	if config.GatewayPort != expected {
-		t.Logf("Expected GatewayPort `%s` actual `%s`\n", expected, config.GatewayPort)
+	expectedGatewayPort := 8080
+	if config.GatewayPort != expectedGatewayPort {
+		t.Logf("Expected GatewayPort `%d` actual `%d`\n", expectedGatewayPort, config.GatewayPort)
 		t.Fail()
 	}
 

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -71,49 +71,49 @@ func Test_ReadConfig(t *testing.T) {
 
 	config := readConfig.Read()
 
-	expected := "test_nats"
-	if config.NatsAddress != expected {
-		t.Logf("Expected NatsAddress `%s` actual `%s`\n", expected, config.NatsAddress)
+	want := "test_nats"
+	if config.NatsAddress != want {
+		t.Logf("Want NatsAddress `%s` got `%s`\n", want, config.NatsAddress)
 		t.Fail()
 	}
 
-	expected = "test_gatewayaddr:8080"
-	if config.GatewayAddress != expected {
-		t.Logf("Expected GatewayAddress `%s` actual `%s`\n", expected, config.GatewayAddress)
+	want = "test_gatewayaddr:8080"
+	if config.GatewayAddress != want {
+		t.Logf("Want GatewayAddress `%s` got `%s`\n", want, config.GatewayAddress)
 		t.Fail()
 	}
 
-	expectedGatewayPort := 8080
-	if config.GatewayPort != expectedGatewayPort {
-		t.Logf("Expected GatewayPort `%d` actual `%d`\n", expectedGatewayPort, config.GatewayPort)
+	wantGatewayPort := 8080
+	if config.GatewayPort != wantGatewayPort {
+		t.Logf("Want GatewayPort `%d` got `%d`\n", wantGatewayPort, config.GatewayPort)
 		t.Fail()
 	}
 
-	expected = "test_suffix"
-	if config.FunctionSuffix != expected {
-		t.Logf("Expected FunctionSuffix `%s` actual `%s`\n", expected, config.FunctionSuffix)
+	want = "test_suffix"
+	if config.FunctionSuffix != want {
+		t.Logf("Want FunctionSuffix `%s` got `%s`\n", want, config.FunctionSuffix)
 		t.Fail()
 	}
 
 	if config.DebugPrintBody != true {
-		t.Logf("Expected DebugPrintBody `%v` actual `%v`\n", true, config.DebugPrintBody)
+		t.Logf("Want DebugPrintBody `%v` got `%v`\n", true, config.DebugPrintBody)
 		t.Fail()
 	}
 
 	if config.WriteDebug != true {
-		t.Logf("Expected WriteDebug `%v` actual `%v`\n", true, config.WriteDebug)
+		t.Logf("Want WriteDebug `%v` got `%v`\n", true, config.WriteDebug)
 		t.Fail()
 	}
 
-	expectedMaxInflight := 10
-	if config.MaxInflight != expectedMaxInflight {
-		t.Logf("Expected maxInflight `%v` actual `%v`\n", expectedMaxInflight, config.MaxInflight)
+	wantMaxInflight := 10
+	if config.MaxInflight != wantMaxInflight {
+		t.Logf("Want maxInflight `%v` got `%v`\n", wantMaxInflight, config.MaxInflight)
 		t.Fail()
 	}
 
-	expectedAckWait := time.Millisecond * 10
-	if config.AckWait != expectedAckWait {
-		t.Logf("Expected maxInflight `%v` actual `%v`\n", expectedAckWait, config.AckWait)
+	wantAckWait := time.Millisecond * 10
+	if config.AckWait != wantAckWait {
+		t.Logf("Want maxInflight `%v` got `%v`\n", wantAckWait, config.AckWait)
 		t.Fail()
 	}
 
@@ -122,15 +122,15 @@ func Test_ReadConfig(t *testing.T) {
 
 	config = readConfig.Read()
 
-	expectedMaxInflight = 1
-	if config.MaxInflight != expectedMaxInflight {
-		t.Logf("Expected maxInflight `%v` actual `%v`\n", expectedMaxInflight, config.MaxInflight)
+	wantMaxInflight = 1
+	if config.MaxInflight != wantMaxInflight {
+		t.Logf("Want maxInflight `%v` got `%v`\n", wantMaxInflight, config.MaxInflight)
 		t.Fail()
 	}
 
-	expectedAckWait = time.Second * 30
-	if config.AckWait != expectedAckWait {
-		t.Logf("Expected maxInflight `%v` actual `%v`\n", expectedAckWait, config.AckWait)
+	wantAckWait = time.Second * 30
+	if config.AckWait != wantAckWait {
+		t.Logf("Want maxInflight `%v` got `%v`\n", wantAckWait, config.AckWait)
 		t.Fail()
 	}
 
@@ -139,15 +139,15 @@ func Test_ReadConfig(t *testing.T) {
 
 	config = readConfig.Read()
 
-	expectedMaxInflight = 1
-	if config.MaxInflight != expectedMaxInflight {
-		t.Logf("Expected maxInflight `%v` actual `%v`\n", expectedMaxInflight, config.MaxInflight)
+	wantMaxInflight = 1
+	if config.MaxInflight != wantMaxInflight {
+		t.Logf("Want maxInflight `%v` got `%v`\n", wantMaxInflight, config.MaxInflight)
 		t.Fail()
 	}
 
-	expectedAckWait = time.Second * 30
-	if config.AckWait != expectedAckWait {
-		t.Logf("Expected ackWait `%v` actual `%v`\n", expectedAckWait, config.AckWait)
+	wantAckWait = time.Second * 30
+	if config.AckWait != wantAckWait {
+		t.Logf("Want ackWait `%v` got `%v`\n", wantAckWait, config.AckWait)
 		t.Fail()
 	}
 }

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -62,6 +62,7 @@ func Test_ReadConfig(t *testing.T) {
 
 	os.Setenv("faas_nats_address", "test_nats")
 	os.Setenv("faas_gateway_address", "test_gatewayaddr")
+	os.Setenv("faas_gateway_port", "test_gatewayport")
 	os.Setenv("faas_function_suffix", "test_suffix")
 	os.Setenv("faas_print_body", "true")
 	os.Setenv("write_debug", "true")
@@ -79,6 +80,12 @@ func Test_ReadConfig(t *testing.T) {
 	expected = "test_gatewayaddr"
 	if config.GatewayAddress != expected {
 		t.Logf("Expected GatewayAddress `%s` actual `%s`\n", expected, config.GatewayAddress)
+		t.Fail()
+	}
+
+	expected = "test_gatewayport"
+	if config.GatewayPort != expected {
+		t.Logf("Expected GatewayPort `%s` actual `%s`\n", expected, config.GatewayPort)
 		t.Fail()
 	}
 

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -77,7 +77,7 @@ func Test_ReadConfig(t *testing.T) {
 		t.Fail()
 	}
 
-	expected = "test_gatewayaddr"
+	expected = "test_gatewayaddr:8080"
 	if config.GatewayAddress != expected {
 		t.Logf("Expected GatewayAddress `%s` actual `%s`\n", expected, config.GatewayAddress)
 		t.Fail()

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -15,7 +15,7 @@ func Test_ReadConfig_GatewayInvokeDefault(t *testing.T) {
 
 	gatewayInvokeWant := false
 	if cfg.GatewayInvoke != gatewayInvokeWant {
-		t.Errorf("gatewayInvokeWant want %v, but got %v", gatewayInvokeWant, cfg.GatewayInvoke)
+		t.Errorf("gatewayInvokeWant want %v, got %v", gatewayInvokeWant, cfg.GatewayInvoke)
 	}
 }
 
@@ -28,7 +28,7 @@ func Test_ReadConfig_GatewayInvokeSetToTrue(t *testing.T) {
 
 	gatewayInvokeWant := true
 	if cfg.GatewayInvoke != gatewayInvokeWant {
-		t.Errorf("gatewayInvokeWant want %v, but got %v", gatewayInvokeWant, cfg.GatewayInvoke)
+		t.Errorf("gatewayInvokeWant want %v, got %v", gatewayInvokeWant, cfg.GatewayInvoke)
 	}
 }
 
@@ -40,7 +40,7 @@ func Test_ReadConfig_BasicAuthDefaultIsFalse(t *testing.T) {
 
 	want := false
 	if cfg.BasicAuth != want {
-		t.Errorf("basicAuth want %v, but got %v", want, cfg.BasicAuth)
+		t.Errorf("basicAuth want %v, got %v", want, cfg.BasicAuth)
 	}
 }
 
@@ -52,7 +52,7 @@ func Test_ReadConfig_BasicAuthSetToTrue(t *testing.T) {
 
 	want := true
 	if cfg.BasicAuth != want {
-		t.Errorf("basicAuth want %v, but got %v", want, cfg.BasicAuth)
+		t.Errorf("basicAuth want %v, got %v", want, cfg.BasicAuth)
 	}
 }
 
@@ -73,47 +73,47 @@ func Test_ReadConfig(t *testing.T) {
 
 	want := "test_nats"
 	if config.NatsAddress != want {
-		t.Logf("Want NatsAddress `%s` got `%s`\n", want, config.NatsAddress)
+		t.Logf("NatsAddress want `%s`, got `%s`\n", want, config.NatsAddress)
 		t.Fail()
 	}
 
 	want = "test_gatewayaddr:8080"
 	if config.GatewayAddress != want {
-		t.Logf("Want GatewayAddress `%s` got `%s`\n", want, config.GatewayAddress)
+		t.Logf("GatewayAddress want `%s`, got `%s`\n", want, config.GatewayAddress)
 		t.Fail()
 	}
 
 	wantGatewayPort := 8080
 	if config.GatewayPort != wantGatewayPort {
-		t.Logf("Want GatewayPort `%d` got `%d`\n", wantGatewayPort, config.GatewayPort)
+		t.Logf("GatewayPort want `%d`, got `%d`\n", wantGatewayPort, config.GatewayPort)
 		t.Fail()
 	}
 
 	want = "test_suffix"
 	if config.FunctionSuffix != want {
-		t.Logf("Want FunctionSuffix `%s` got `%s`\n", want, config.FunctionSuffix)
+		t.Logf("FunctionSuffix want `%s`, got `%s`\n", want, config.FunctionSuffix)
 		t.Fail()
 	}
 
 	if config.DebugPrintBody != true {
-		t.Logf("Want DebugPrintBody `%v` got `%v`\n", true, config.DebugPrintBody)
+		t.Logf("DebugPrintBody want `%v`, got `%v`\n", true, config.DebugPrintBody)
 		t.Fail()
 	}
 
 	if config.WriteDebug != true {
-		t.Logf("Want WriteDebug `%v` got `%v`\n", true, config.WriteDebug)
+		t.Logf("WriteDebug want `%v`, got `%v`\n", true, config.WriteDebug)
 		t.Fail()
 	}
 
 	wantMaxInflight := 10
 	if config.MaxInflight != wantMaxInflight {
-		t.Logf("Want maxInflight `%v` got `%v`\n", wantMaxInflight, config.MaxInflight)
+		t.Logf("maxInflight want `%v`, got `%v`\n", wantMaxInflight, config.MaxInflight)
 		t.Fail()
 	}
 
 	wantAckWait := time.Millisecond * 10
 	if config.AckWait != wantAckWait {
-		t.Logf("Want maxInflight `%v` got `%v`\n", wantAckWait, config.AckWait)
+		t.Logf("maxInflight want `%v`, got `%v`\n", wantAckWait, config.AckWait)
 		t.Fail()
 	}
 
@@ -124,13 +124,13 @@ func Test_ReadConfig(t *testing.T) {
 
 	wantMaxInflight = 1
 	if config.MaxInflight != wantMaxInflight {
-		t.Logf("Want maxInflight `%v` got `%v`\n", wantMaxInflight, config.MaxInflight)
+		t.Logf("maxInflight want `%v`, got `%v`\n", wantMaxInflight, config.MaxInflight)
 		t.Fail()
 	}
 
 	wantAckWait = time.Second * 30
 	if config.AckWait != wantAckWait {
-		t.Logf("Want maxInflight `%v` got `%v`\n", wantAckWait, config.AckWait)
+		t.Logf("maxInflight want `%v`, got `%v`\n", wantAckWait, config.AckWait)
 		t.Fail()
 	}
 
@@ -141,13 +141,13 @@ func Test_ReadConfig(t *testing.T) {
 
 	wantMaxInflight = 1
 	if config.MaxInflight != wantMaxInflight {
-		t.Logf("Want maxInflight `%v` got `%v`\n", wantMaxInflight, config.MaxInflight)
+		t.Logf("maxInflight want `%v`, got `%v`\n", wantMaxInflight, config.MaxInflight)
 		t.Fail()
 	}
 
 	wantAckWait = time.Second * 30
 	if config.AckWait != wantAckWait {
-		t.Logf("Want ackWait `%v` got `%v`\n", wantAckWait, config.AckWait)
+		t.Logf("ackWait want `%v`, got `%v`\n", wantAckWait, config.AckWait)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
## Description
Allows the User to configure a custom GatewayPort in nats-queue-worker. Fixes #59.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
