### PR TITLE
fix bad use of http.Response

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 		var status int
 		var functionResult []byte
 
-		statusCode := res.StatusCode
+		var statusCode int
 		if err != nil {
 			statusCode = http.StatusServiceUnavailable
 		}
@@ -145,6 +145,8 @@ func main() {
 				}
 				return
 			}
+		} else {
+			statusCode = res.StatusCode
 		}
 
 		if res.Body != nil {


### PR DESCRIPTION
Signed-off-by: chennqqi <chennqqi@qq.com>

fix bad use of http.Response

## Description
fix bad use of http.Response
http.Response arguments of client.Do(request) only can be call if err == nil

## Motivation and Context


## How Has This Been Tested?
tested
add panic function into faas function 
then do a sync call to check if nats-worker crash


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
