### PR TITLE
Allow for customizing the NATS Streaming port and cluster name (and fix tests).

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Screenshots from keynote / video - find out more over at https://www.openfaas.co
 | `faas_gateway_port` | Port of gateway service | `8080` |
 | `faas_function_suffix` | When `gateway_invoke` is `false`, this suffix is used to contact a function, it may correspond to a Kubernetes namespace  | `` |
 | `faas_max_reconnect` | An integer of the amount of reconnection attempts when the NATS connection is lost | `120` |
-| `faas_nats_address` | The DNS entry for NATS | `nats` |
+| `faas_nats_address` | The host at which NATS Streaming can be reached | `nats` |
+| `faas_nats_port` | The port at which NATS Streaming can be reached | `4222` |
+| `faas_nats_cluster_name` | The name of the target NATS Streaming cluster | `faas-cluster` |
 | `faas_reconnect_delay` | Delay between retrying to connect to NATS | `2s` |
 | `faas_print_body` | Print the body of the function invocation | `false` |

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -7,17 +7,16 @@ import (
 )
 
 // CreateNATSQueue ready for asynchronous processing
-func CreateNATSQueue(address string, port int, clientConfig NATSConfig) (*NATSQueue, error) {
+func CreateNATSQueue(address string, port int, clusterName string, clientConfig NATSConfig) (*NATSQueue, error) {
 	var err error
 	natsURL := fmt.Sprintf("nats://%s:%d", address, port)
 	log.Printf("Opening connection to %s\n", natsURL)
 
 	clientID := clientConfig.GetClientID()
-	clusterID := "faas-cluster"
 
 	queue1 := NATSQueue{
 		ClientID:       clientID,
-		ClusterID:      clusterID,
+		ClusterID:      clusterName,
 		NATSURL:        natsURL,
 		Topic:          "faas-request",
 		maxReconnect:   clientConfig.GetMaxReconnect(),

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func main() {
 	natsURL := fmt.Sprintf("nats://%s:%d", config.NatsAddress, config.NatsPort)
 
 	natsQueue := NATSQueue{
-		clusterID: "faas-cluster",
+		clusterID: config.NatsClusterName,
 		clientID:  "faas-worker-" + nats.GetClientID(hostname),
 		natsURL:   natsURL,
 

--- a/main.go
+++ b/main.go
@@ -37,8 +37,9 @@ func makeFunctionURL(req *queue.Request, config *QueueWorkerConfig, path, queryS
 		qs)
 
 	if config.GatewayInvoke {
-		functionURL = fmt.Sprintf("http://%s/function/%s%s%s",
+		functionURL = fmt.Sprintf("http://%s:%d/function/%s%s%s",
 			config.GatewayAddress,
+			config.GatewayPort,
 			strings.Trim(req.Function, "/"),
 			pathVal,
 			qs)
@@ -197,7 +198,7 @@ func main() {
 
 	}
 
-	natsURL := "nats://" + config.NatsAddress + ":4222"
+	natsURL := fmt.Sprintf("nats://%s:%d", config.NatsAddress, config.NatsPort)
 
 	natsQueue := NATSQueue{
 		clusterID: "faas-cluster",

--- a/main_test.go
+++ b/main_test.go
@@ -11,7 +11,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_IncludesGWAddress(t *testi
 		FunctionSuffix: "",
 		GatewayInvoke:  true,
 		GatewayAddress: "gateway",
-		GatewayPort: "8080",
+		GatewayPort:    8080,
 	}
 	req := queue.Request{
 		Function: "function1",
@@ -30,7 +30,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_WithQS(t *testing.T) {
 		FunctionSuffix: "",
 		GatewayInvoke:  true,
 		GatewayAddress: "gateway",
-		GatewayPort: "8080",
+		GatewayPort:    8080,
 	}
 	req := queue.Request{
 		Function:    "function1",
@@ -49,7 +49,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvoke_WithPath(t *testing.T) {
 		FunctionSuffix: "",
 		GatewayInvoke:  true,
 		GatewayAddress: "gateway",
-		GatewayPort: "8080",
+		GatewayPort:    8080,
 	}
 	req := queue.Request{
 		Function: "function1",
@@ -68,7 +68,7 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvokeOff_UsesDirectInvocation(t 
 		FunctionSuffix: ".openfaas-fn",
 		GatewayInvoke:  false,
 		GatewayAddress: "gateway",
-		GatewayPort: "8080",
+		GatewayPort:    8080,
 	}
 	req := queue.Request{
 		Function: "function1",

--- a/readconfig.go
+++ b/readconfig.go
@@ -39,6 +39,12 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		cfg.NatsPort = 4222
 	}
 
+	if val, exists := os.LookupEnv("faas_nats_cluster_name"); exists {
+		cfg.NatsClusterName = val
+	} else {
+		cfg.NatsClusterName = "faas-cluster"
+	}
+
 	if val, exists := os.LookupEnv("faas_gateway_address"); exists {
 		cfg.GatewayAddress = val
 	} else {
@@ -137,17 +143,18 @@ func (ReadConfig) Read() QueueWorkerConfig {
 }
 
 type QueueWorkerConfig struct {
-	NatsAddress    string
-	NatsPort       int
-	GatewayAddress string
-	GatewayPort    int
-	FunctionSuffix string
-	DebugPrintBody bool
-	WriteDebug     bool
-	MaxInflight    int
-	AckWait        time.Duration
-	MaxReconnect   int
-	ReconnectDelay time.Duration
-	GatewayInvoke  bool // GatewayInvoke invoke functions through gateway rather than directly
-	BasicAuth      bool
+	NatsAddress     string
+	NatsPort        int
+	NatsClusterName string
+	GatewayAddress  string
+	GatewayPort     int
+	FunctionSuffix  string
+	DebugPrintBody  bool
+	WriteDebug      bool
+	MaxInflight     int
+	AckWait         time.Duration
+	MaxReconnect    int
+	ReconnectDelay  time.Duration
+	GatewayInvoke   bool // GatewayInvoke invoke functions through gateway rather than directly
+	BasicAuth       bool
 }

--- a/readconfig.go
+++ b/readconfig.go
@@ -28,6 +28,17 @@ func (ReadConfig) Read() QueueWorkerConfig {
 		cfg.NatsAddress = "nats"
 	}
 
+	if value, exists := os.LookupEnv("faas_nats_port"); exists {
+		val, err := strconv.Atoi(value)
+		if err != nil {
+			log.Println("converting faas_nats_port to int error:", err)
+		} else {
+			cfg.NatsPort = val
+		}
+	} else {
+		cfg.NatsPort = 4222
+	}
+
 	if val, exists := os.LookupEnv("faas_gateway_address"); exists {
 		cfg.GatewayAddress = val
 	} else {
@@ -127,6 +138,7 @@ func (ReadConfig) Read() QueueWorkerConfig {
 
 type QueueWorkerConfig struct {
 	NatsAddress    string
+	NatsPort       int
 	GatewayAddress string
 	GatewayPort    int
 	FunctionSuffix string

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -61,6 +61,7 @@ func Test_ReadConfig(t *testing.T) {
 	readConfig := ReadConfig{}
 
 	os.Setenv("faas_nats_address", "test_nats")
+	os.Setenv("faas_nats_port", "1234")
 	os.Setenv("faas_gateway_address", "test_gatewayaddr")
 	os.Setenv("faas_gateway_port", "8080")
 	os.Setenv("faas_function_suffix", "test_suffix")
@@ -74,6 +75,12 @@ func Test_ReadConfig(t *testing.T) {
 	want := "test_nats"
 	if config.NatsAddress != want {
 		t.Logf("NatsAddress want `%s`, got `%s`\n", want, config.NatsAddress)
+		t.Fail()
+	}
+
+	wantNatsPort := 1234
+	if config.NatsPort != wantNatsPort {
+		t.Logf("NatsPort want `%d`, got `%d`\n", wantNatsPort, config.NatsPort)
 		t.Fail()
 	}
 

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -62,6 +62,7 @@ func Test_ReadConfig(t *testing.T) {
 
 	os.Setenv("faas_nats_address", "test_nats")
 	os.Setenv("faas_nats_port", "1234")
+	os.Setenv("faas_nats_cluster_name", "example-nats-cluster")
 	os.Setenv("faas_gateway_address", "test_gatewayaddr")
 	os.Setenv("faas_gateway_port", "8080")
 	os.Setenv("faas_function_suffix", "test_suffix")
@@ -81,6 +82,12 @@ func Test_ReadConfig(t *testing.T) {
 	wantNatsPort := 1234
 	if config.NatsPort != wantNatsPort {
 		t.Logf("NatsPort want `%d`, got `%d`\n", wantNatsPort, config.NatsPort)
+		t.Fail()
+	}
+
+	wantNatsClusterName := "example-nats-cluster"
+	if config.NatsClusterName != wantNatsClusterName {
+		t.Logf("NatsClusterName want `%s`, got `%s`\n", wantNatsClusterName, config.NatsClusterName)
 		t.Fail()
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR allows for customizing the NATS Streaming port and cluster name via `faas_nats_port` and `faas_nats_cluster_name`, respectively. It also fixes tests that are currently failing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Part of this has been discussed in #70.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
