### PR TITLE
Fix duplicate port in 'config.GatewayAddress' and misplaced 'return' causing panics.

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,8 +146,8 @@ func main() {
 				} else {
 					log.Printf("Posting report - %d\n", statusCode)
 				}
-				return
 			}
+			return
 		}
 
 		if res.Body != nil {

--- a/readconfig.go
+++ b/readconfig.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -61,8 +60,6 @@ func (ReadConfig) Read() QueueWorkerConfig {
 	} else {
 		cfg.GatewayPort = 8080
 	}
-
-	cfg.GatewayAddress = fmt.Sprintf("%s:%d", cfg.GatewayAddress, cfg.GatewayPort)
 
 	if val, exists := os.LookupEnv("faas_function_suffix"); exists {
 		cfg.FunctionSuffix = val

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -91,7 +91,7 @@ func Test_ReadConfig(t *testing.T) {
 		t.Fail()
 	}
 
-	want = "test_gatewayaddr:8080"
+	want = "test_gatewayaddr"
 	if config.GatewayAddress != want {
 		t.Logf("GatewayAddress want `%s`, got `%s`\n", want, config.GatewayAddress)
 		t.Fail()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, `gateway_invoke=true` causes the app to panic because...

* ... the gateway port appears twice in the function URL, causing an error while invoking.
* ... the error handling code seems to have a misplaced `return` statement, which causes a nil-pointer dereference.

```
(...)
[#1] Received on [faas-request]: 'sequence:4 subject:"faas-request" data:"{\"Header\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"4\"],\"Content-Type\":[\"text/plain\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Call-Id\":[\"98d0c49d-a33e-48b5-bb7a-75e312338387
\"],\"X-Callback-Url\":[\"http://10.35.109.179/anything\"],\"X-Start-Time\":[\"1574699946469186903\"]},\"Host\":\"127.0.0.1:8080\",\"Body\":\"cXV4Cg==\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"figlet\",\"CallbackUrl\":{\"Scheme\":\"http\",\"$
paque\":\"\",\"User\":null,\"Host\":\"10.35.109.179\",\"Path\":\"/anything\",\"RawPath\":\"\",\"ForceQuery\":false,\"RawQuery\":\"\",\"Fragment\":\"\"}}" timestamp:1574699946470133496 redelivered:true '
Invoking: figlet, 4 bytes.
Invoked: figlet [503] in 0.000193s
Post http://gateway.openfaas.svc.cluster.local:8080:8080/function/figlet/: dial tcp: lookup gateway.openfaas.svc.cluster.local:0: no such host
Callback to: http://10.35.109.179/anything
Posted result: 200
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x6c6c36]

goroutine 25 [running]:
main.main.func1(0xc000050b40)
        /go/src/github.com/openfaas/nats-queue-worker/main.go:153 +0x826
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By building the image (`bmcstdio/openfaas-queue-worker:gateway-addr`), deploying it and making sure the behaviour is fixed.

```
(...)
[#1] Received on [faas-request]: 'sequence:18 subject:"faas-request" data:"{\"Header\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"4\"],\"Content-Type\":[\"text/plain\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Call-Id\":[\"267dafe4-d0f9-4308-92d7-04718d594bf
e\"],\"X-Start-Time\":[\"1574702158491557701\"]},\"Host\":\"127.0.0.1:8080\",\"Body\":\"YmF6Cg==\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"figlet\",\"CallbackUrl\":null}" timestamp:1574702158492447449 '
Invoking: figlet, 4 bytes.
Wrote 108 Bytes
200 OK
Invoked: figlet [200] in 0.014991s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
