### PR TITLE
Support durable queue subscriptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Screenshots from keynote / video - find out more over at https://www.openfaas.co
 | `faas_nats_address` | The host at which NATS Streaming can be reached | `nats` |
 | `faas_nats_port` | The port at which NATS Streaming can be reached | `4222` |
 | `faas_nats_cluster_name` | The name of the target NATS Streaming cluster | `faas-cluster` |
+| `faas_nats_durable_queue_subscription` | Whether to use a durable queue subscription | `false` |
 | `faas_reconnect_delay` | Delay between retrying to connect to NATS | `2s` |
 | `faas_print_body` | Print the body of the function invocation | `false` |
 

--- a/main.go
+++ b/main.go
@@ -33,6 +33,10 @@ func main() {
 	hostname, _ := os.Hostname()
 
 	var durable string
+	if config.NatsDurableQueueSubscription {
+		durable = "faas"
+	}
+
 	var unsubscribe bool
 	var credentials *auth.BasicAuthCredentials
 	var err error

--- a/readconfig.go
+++ b/readconfig.go
@@ -45,6 +45,14 @@ func (ReadConfig) Read() (QueueWorkerConfig, error) {
 		cfg.NatsClusterName = "faas-cluster"
 	}
 
+	if val, exists := os.LookupEnv("faas_nats_durable_queue_subscription"); exists {
+		if v, err := strconv.ParseBool(val); err == nil {
+			cfg.NatsDurableQueueSubscription = v
+		} else {
+			cfg.NatsDurableQueueSubscription = false
+		}
+	}
+
 	if val, exists := os.LookupEnv("faas_gateway_address"); exists {
 		cfg.GatewayAddress = val
 	} else {
@@ -142,11 +150,12 @@ func (ReadConfig) Read() (QueueWorkerConfig, error) {
 }
 
 type QueueWorkerConfig struct {
-	NatsAddress     string
-	NatsPort        int
-	NatsClusterName string
-	GatewayAddress  string
+	NatsAddress                  string
+	NatsPort                     int
+	NatsClusterName              string
+	NatsDurableQueueSubscription bool
 
+	GatewayAddress string
 	GatewayPort    int
 	FunctionSuffix string
 	DebugPrintBody bool

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -77,6 +77,7 @@ func Test_ReadConfig(t *testing.T) {
 	os.Setenv("faas_nats_address", "test_nats")
 	os.Setenv("faas_nats_port", "1234")
 	os.Setenv("faas_nats_cluster_name", "example-nats-cluster")
+	os.Setenv("faas_nats_durable_queue_subscription", "true")
 	os.Setenv("faas_gateway_address", "test_gatewayaddr")
 	os.Setenv("faas_gateway_port", "8080")
 	os.Setenv("faas_function_suffix", "test_suffix")
@@ -102,6 +103,12 @@ func Test_ReadConfig(t *testing.T) {
 	wantNatsClusterName := "example-nats-cluster"
 	if config.NatsClusterName != wantNatsClusterName {
 		t.Logf("NatsClusterName want `%s`, got `%s`\n", wantNatsClusterName, config.NatsClusterName)
+		t.Fail()
+	}
+
+	wantNatsDurableQueueSubscription := true
+	if config.NatsDurableQueueSubscription != wantNatsDurableQueueSubscription {
+		t.Logf("NatsDurableQueueSubscription want `%t`, got `%t`\n", wantNatsDurableQueueSubscription, config.NatsDurableQueueSubscription)
 		t.Fail()
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds support for [durable queue subscriptions](https://docs.nats.io/nats-streaming-concepts/channels/subscriptions/queue-group) while maintaing the implementation backwards-compatibility. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#75.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using the steps described in #75 while using the `bmcstdio/openfaas-nats-queue-worker:nats-durable-queue-subscription` image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
