### PR TITLE
Set X-Duration-Seconds header on timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,7 +111,8 @@ func main() {
 					functionResult,
 					req.CallbackURL.String(),
 					xCallID,
-					status)
+					status,
+					timeTaken)
 
 				if resultErr != nil {
 					log.Printf("Posted callback to: %s - status %d, error: %s\n", req.CallbackURL.String(), http.StatusServiceUnavailable, resultErr.Error())
@@ -160,7 +161,8 @@ func main() {
 				functionResult,
 				req.CallbackURL.String(),
 				xCallID,
-				res.StatusCode)
+				res.StatusCode,
+				timeTaken)
 
 			if resultErr != nil {
 				log.Printf("Error posting to callback-url: %s\n", resultErr)
@@ -252,8 +254,12 @@ func makeClient() http.Client {
 	return proxyClient
 }
 
-func postResult(client *http.Client, functionRes *http.Response, result []byte, callbackURL string, xCallID string, statusCode int) (int, error) {
+func postResult(client *http.Client, functionRes *http.Response, result []byte, callbackURL string, xCallID string, statusCode int, timeTaken float64) (int, error) {
 	var reader io.Reader
+
+	if functionRes.Header.Get("X-Duration-Seconds") == "" {
+		functionRes.Header.Set("X-Duration-Seconds", fmt.Sprintf("%f", timeTaken))
+	}
 
 	if result != nil {
 		reader = bytes.NewReader(result)


### PR DESCRIPTION
Set X-Duration-Seconds header when original function call exceeds
timeout.

Fixes #77

Signed-off-by: Edward Wilde <ewilde@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested on Mac OS with docker swarm

1. Created function `a` with that sleeps longer than timeout
2. Created callback function that prints X-Duration-Seconds header

### Before change
Logs from callback function

```
2019/12/09 02:56:41 stderr: 2019/12/09 02:56:41 Status:[502], time:[], body:
```

### After change
Logs from callback function

```
2019/12/09 03:23:20 Status:[502], time:[10.024013], body:
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
