### PR TITLE
Support customising the NATS Streaming channel and queue group.

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -7,18 +7,23 @@ import (
 )
 
 // CreateNATSQueue ready for asynchronous processing
-func CreateNATSQueue(address string, port int, clusterName string, clientConfig NATSConfig) (*NATSQueue, error) {
+func CreateNATSQueue(address string, port int, clusterName, channel string, clientConfig NATSConfig) (*NATSQueue, error) {
 	var err error
 	natsURL := fmt.Sprintf("nats://%s:%d", address, port)
 	log.Printf("Opening connection to %s\n", natsURL)
 
 	clientID := clientConfig.GetClientID()
 
+	// If 'channel' is empty, use the previous default.
+	if channel == "" {
+		channel = "faas-request"
+	}
+
 	queue1 := NATSQueue{
 		ClientID:       clientID,
 		ClusterID:      clusterName,
 		NATSURL:        natsURL,
-		Topic:          "faas-request",
+		Topic:          channel,
 		maxReconnect:   clientConfig.GetMaxReconnect(),
 		reconnectDelay: clientConfig.GetReconnectDelay(),
 		ncMutex:        &sync.RWMutex{},

--- a/main.go
+++ b/main.go
@@ -196,8 +196,8 @@ func main() {
 		reconnectDelay: config.ReconnectDelay,
 		quitCh:         make(chan struct{}),
 
-		subject:        "faas-request",
-		qgroup:         "faas",
+		subject:        config.NatsChannel,
+		qgroup:         config.NatsQueueGroup,
 		durable:        durable,
 		messageHandler: messageHandler,
 		startOption:    stan.StartWithLastReceived(),

--- a/readconfig.go
+++ b/readconfig.go
@@ -53,6 +53,18 @@ func (ReadConfig) Read() (QueueWorkerConfig, error) {
 		}
 	}
 
+	if val, exists := os.LookupEnv("faas_nats_channel"); exists && val != "" {
+		cfg.NatsChannel = val
+	} else {
+		cfg.NatsChannel = "faas-request"
+	}
+
+	if val, exists := os.LookupEnv("faas_nats_queue_group"); exists && val != "" {
+		cfg.NatsQueueGroup = val
+	} else {
+		cfg.NatsQueueGroup = "faas"
+	}
+
 	if val, exists := os.LookupEnv("faas_gateway_address"); exists {
 		cfg.GatewayAddress = val
 	} else {
@@ -154,6 +166,8 @@ type QueueWorkerConfig struct {
 	NatsPort                     int
 	NatsClusterName              string
 	NatsDurableQueueSubscription bool
+	NatsChannel                  string
+	NatsQueueGroup               string
 
 	GatewayAddress string
 	GatewayPort    int

--- a/readconfig_test.go
+++ b/readconfig_test.go
@@ -78,6 +78,8 @@ func Test_ReadConfig(t *testing.T) {
 	os.Setenv("faas_nats_port", "1234")
 	os.Setenv("faas_nats_cluster_name", "example-nats-cluster")
 	os.Setenv("faas_nats_durable_queue_subscription", "true")
+	os.Setenv("faas_nats_channel", "foo")
+	os.Setenv("faas_nats_queue_group", "bar")
 	os.Setenv("faas_gateway_address", "test_gatewayaddr")
 	os.Setenv("faas_gateway_port", "8080")
 	os.Setenv("faas_function_suffix", "test_suffix")
@@ -109,6 +111,17 @@ func Test_ReadConfig(t *testing.T) {
 	wantNatsDurableQueueSubscription := true
 	if config.NatsDurableQueueSubscription != wantNatsDurableQueueSubscription {
 		t.Logf("NatsDurableQueueSubscription want `%t`, got `%t`\n", wantNatsDurableQueueSubscription, config.NatsDurableQueueSubscription)
+	}
+
+	want = "foo"
+	if config.NatsChannel != want {
+		t.Logf("NatsChannel want `%s`, got `%s`\n", want, config.NatsChannel)
+		t.Fail()
+	}
+
+	want = "bar"
+	if config.NatsQueueGroup != want {
+		t.Logf("NatsQueueGroup want `%s`, got `%s`\n", want, config.NatsQueueGroup)
 		t.Fail()
 	}
 
@@ -190,5 +203,29 @@ func Test_ReadConfig(t *testing.T) {
 	if config.AckWait != wantAckWait {
 		t.Logf("ackWait want `%v`, got `%v`\n", wantAckWait, config.AckWait)
 		t.Fail()
+	}
+}
+
+func Test_ReadConfig_NatsChannelDefault(t *testing.T) {
+	readConfig := ReadConfig{}
+
+	os.Setenv("faas_nats_channel", "")
+	cfg, _ := readConfig.Read()
+
+	want := "faas-request"
+	if cfg.NatsChannel != want {
+		t.Errorf("NatsChannel want %v, got %v", want, cfg.NatsChannel)
+	}
+}
+
+func Test_ReadConfig_NatsQueueGroup(t *testing.T) {
+	readConfig := ReadConfig{}
+
+	os.Setenv("faas_nats_queue_group", "")
+	cfg, _ := readConfig.Read()
+
+	want := "faas"
+	if cfg.NatsQueueGroup != want {
+		t.Errorf("NatsQueueGroup want %v, got %v", want, cfg.NatsQueueGroup)
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds support for customising the NATS Streaming channel and queue group used for asynchronous invocations, as per https://github.com/openfaas/faas/issues/1399, in a backwards-compatible way.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

https://github.com/openfaas/faas/issues/1399

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By running the included unit tests, which is enough in this case IMHO. There's also `bmcstdio/openfaas-nats-queue-worker:pr-79`, just in case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
