### PR TITLE
Original function name in callback meta-data

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func main() {
 					req.CallbackURL.String(),
 					xCallID,
 					status,
+					req.Function,
 					timeTaken)
 
 				if resultErr != nil {
@@ -166,6 +167,7 @@ func main() {
 				req.CallbackURL.String(),
 				xCallID,
 				res.StatusCode,
+				req.Function,
 				timeTaken)
 
 			if resultErr != nil {
@@ -258,7 +260,8 @@ func makeClient() http.Client {
 	return proxyClient
 }
 
-func postResult(client *http.Client, functionRes *http.Response, result []byte, callbackURL string, xCallID string, statusCode int, timeTaken float64) (int, error) {
+func postResult(client *http.Client, functionRes *http.Response, result []byte, callbackURL string, xCallID string,
+	statusCode int, functionName string, timeTaken float64) (int, error) {
 	var reader io.Reader
 
 	if functionRes.Header.Get("X-Duration-Seconds") == "" {
@@ -280,6 +283,7 @@ func postResult(client *http.Client, functionRes *http.Response, result []byte, 
 	}
 
 	request.Header.Set("X-Function-Status", fmt.Sprintf("%d", statusCode))
+	request.Header.Set("X-Function-Name", functionName)
 
 	if len(xCallID) > 0 {
 		request.Header.Set("X-Call-Id", xCallID)


### PR DESCRIPTION
## Description
Adds original function name in callback meta-data `X-Function-Name`

## Motivation and Context
- [x] I have raised an issue #82 to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested on docker swarm:

- Invoke function `a` (in this example called echo) asynchronously provide callback to function b
- verify header is set

Logs for function b
```
2019-12-10T21:17:05Z 2019/12/10 21:17:05 stderr: 2019/12/10 21:17:05 Function: [echo], status:[200], time:[0.001863], body:OK
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly see: https://github.com/openfaas/docs/pull/195.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
