### PR TITLE
Fixed bad pointer when function fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -261,10 +261,6 @@ func makeClient() http.Client {
 func postResult(client *http.Client, functionRes *http.Response, result []byte, callbackURL string, xCallID string, statusCode int, timeTaken float64) (int, error) {
 	var reader io.Reader
 
-	if functionRes.Header.Get("X-Duration-Seconds") == "" {
-		functionRes.Header.Set("X-Duration-Seconds", fmt.Sprintf("%f", timeTaken))
-	}
-
 	if result != nil {
 		reader = bytes.NewReader(result)
 	}
@@ -276,6 +272,9 @@ func postResult(client *http.Client, functionRes *http.Response, result []byte, 
 	}
 
 	if functionRes != nil {
+		if functionRes.Header.Get("X-Duration-Seconds") == "" {
+			functionRes.Header.Set("X-Duration-Seconds", fmt.Sprintf("%f", timeTaken))
+		}
 		copyHeaders(request.Header, &functionRes.Header)
 	}
 

--- a/main.go
+++ b/main.go
@@ -272,12 +272,10 @@ func postResult(client *http.Client, functionRes *http.Response, result []byte, 
 	}
 
 	if functionRes != nil {
-		if functionRes.Header.Get("X-Duration-Seconds") == "" {
-			functionRes.Header.Set("X-Duration-Seconds", fmt.Sprintf("%f", timeTaken))
-		}
 		copyHeaders(request.Header, &functionRes.Header)
 	}
 
+	request.Header.Set("X-Duration-Seconds", fmt.Sprintf("%f", timeTaken))
 	request.Header.Set("X-Function-Status", fmt.Sprintf("%d", statusCode))
 
 	if len(xCallID) > 0 {


### PR DESCRIPTION
If function call ends up giving 503, `nats-queue-worker` crashes with `panic: runtime error: invalid memory address or nil pointer dereference` when trying to do callback.

## Description
If `X-Callback-Url` is set, and the function call gives 503, `functionRes` is `nil`, but we try to evaluate `functionRes.Header.Get("X-Duration-Seconds")` in the `postResult` function. This leads to null pointer error and a dying pod. The call is then being retried multiple times on any new queue-worker pod starting.

This PR adds the timeout directly to the headers instead.

## Motivation and Context
Crashing queue worker in the state mentioned above.

- [x] I have raised an issue to propose this change ([required]
https://github.com/openfaas/nats-queue-worker/issues/90
## How Has This Been Tested?
I have patched the worker and tried with and without the change and verified that it does not crash with this patch. I tested this with the following images
```
['prom/alertmanager:v0.18.0', 'openfaas/basic-auth-plugin:0.18.11', 'openfaas/faas-idler:0.3.0', 'openfaas/gateway:0.18.13', 'openfaas/faas-netes:0.10.2-rc1', 'nats-streaming:0.17.0', 'prom/prometheus:v2.11.0', 'eu.gcr.io/cognitedata-development/queue-worker:debug2-amd64']
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
