### PR TITLE
Fixes #92: show built version and SHA on start-up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,29 @@ WORKDIR /go/src/github.com/openfaas/nats-queue-worker
 
 COPY vendor     vendor
 COPY handler    handler
+COPY version    version
 COPY nats       nats
 COPY main.go  .
 COPY types.go .
 COPY readconfig.go .
 COPY readconfig_test.go .
 COPY auth.go .
+COPY .git     .
 
 ARG go_opts
 
-RUN env $go_opts CGO_ENABLED=0 go build -a -installsuffix cgo -o app . \
-  && addgroup -S app \
-  && adduser -S -g app app \
-  && mkdir /scratch-tmp
+RUN apk add --no-cache git
+
+RUN  VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
+    && GIT_COMMIT=$(git rev-list -1 HEAD) \
+    && env $go_opts CGO_ENABLED=0 go build \
+        --ldflags "-s -w \
+        -X github.com/openfaas/nats-queue-worker/version.GitCommit=${GIT_COMMIT}\
+        -X github.com/openfaas/nats-queue-worker/version.Version=${VERSION}" \
+        -a -installsuffix cgo -o app . \
+    && addgroup -S app \
+    && adduser -S -g app app \
+    && mkdir /scratch-tmp
 
 # we can't add user in next stage because it's from scratch
 # ca-certificates and tmp folder are also missing in scratch

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openfaas/faas-provider/auth"
 	"github.com/openfaas/faas/gateway/queue"
 	"github.com/openfaas/nats-queue-worker/nats"
+	"github.com/openfaas/nats-queue-worker/version"
 )
 
 func main() {
@@ -50,6 +51,9 @@ func main() {
 			log.Printf("Error with LoadCredentials: %s ", err.Error())
 		}
 	}
+
+	sha, release := version.GetReleaseInfo()
+	log.Printf("Starting queue-worker. Version: %s\tGit Commit: %s", release, sha)
 
 	client := makeClient(config.TLSInsecure)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,25 @@
+package version
+
+var (
+	// Version release version of the provider
+	Version string
+
+	// GitCommit SHA of the last git commit
+	GitCommit string
+
+	// DevVersion string for the development version
+	DevVersion = "dev"
+)
+
+// BuildVersion returns current version of the provider
+func BuildVersion() string {
+	if len(Version) == 0 {
+		return DevVersion
+	}
+	return Version
+}
+
+// GetReleaseInfo includes the SHA and the release version
+func GetReleaseInfo() (sha, release string) {
+	return GitCommit, BuildVersion()
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit will solve issue #92 which will show built version and SHA on start-up.

Signed-off-by: Amal Alkhamees <amalkms5@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Build the app
```
$ make build-armhf       
docker build --build-arg http_proxy="" --build-arg https_proxy="" --build-arg go_opts="GOARCH=arm GOARM=6" -t openfaas/queue-worker:latest-armhf .
Sending build context to Docker daemon  6.094MB
Step 1/27 : FROM golang:1.13-alpine as golang
 ---> 3369136a43d1
Step 2/27 : ENV CGO_ENABLED=0
 ---> Using cache
 ---> aa2528b92ad6
Step 3/27 : ENV GO111MODULE=off
 ---> Using cache
 ---> ee23b83c98b9
Step 4/27 : WORKDIR /go/src/github.com/openfaas/nats-queue-worker
 ---> Using cache
 ---> 312f1a317d8e
Step 5/27 : COPY vendor     vendor
 ---> Using cache
 ---> 8a1ba99e13e4
Step 6/27 : COPY handler    handler
 ---> Using cache
 ---> 4b351989c667
Step 7/27 : COPY version    version
 ---> Using cache
 ---> e0583954c890
Step 8/27 : COPY nats       nats
 ---> Using cache
 ---> 156a910dde5f
Step 9/27 : COPY main.go  .
 ---> 1b74c670c7cc
Step 10/27 : COPY types.go .
 ---> 31e6914ec333
Step 11/27 : COPY readconfig.go .
 ---> 02e747d8b9a3
Step 12/27 : COPY readconfig_test.go .
 ---> 90c5147c19b4
Step 13/27 : COPY auth.go .
 ---> 4012d8aa241c
Step 14/27 : COPY .git     .
 ---> f353cd3a75e6
Step 15/27 : ARG go_opts
 ---> Running in 907f32fdae6a
Removing intermediate container 907f32fdae6a
 ---> c6ab9981df73
Step 16/27 : RUN apk add --no-cache git
 ---> Running in 01a6d50fff12
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
(1/5) Installing nghttp2-libs (1.40.0-r0)
(2/5) Installing libcurl (7.67.0-r0)
(3/5) Installing expat (2.2.9-r1)
(4/5) Installing pcre2 (10.34-r1)
(5/5) Installing git (2.24.3-r0)
Executing busybox-1.31.1-r9.trigger
OK: 22 MiB in 20 packages
Removing intermediate container 01a6d50fff12
 ---> 7f7bd6942c1c
Step 17/27 : RUN  VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///')     && GIT_COMMIT=$(git rev-list -1 HEAD)     && env $go_opts CGO_ENABLED=0 go build         --ldflags "-s -w         -X github.com/openfaas/nats-queue-worker/version.GitCommit=${GIT_COMMIT}        -X github.com/openfaas/nats-queue-worker/version.Version=${VERSION}"         -a -installsuffix cgo -o app .     && addgroup -S app     && adduser -S -g app app     && mkdir /scratch-tmp
 ---> Running in 05c7dadb99e5
Removing intermediate container 05c7dadb99e5
 ---> 6e17f5d37444
Step 18/27 : FROM scratch
 ---> 
Step 19/27 : EXPOSE 8080
 ---> Using cache
 ---> dbb3305e45bf
Step 20/27 : ENV http_proxy      ""
 ---> Using cache
 ---> c0c061819d6e
Step 21/27 : ENV https_proxy     ""
 ---> Using cache
 ---> c042be336103
Step 22/27 : USER app
 ---> Using cache
 ---> a313f1ea1e99
Step 23/27 : COPY --from=golang /etc/passwd /etc/group /etc/
 ---> Using cache
 ---> 25b6a012f427
Step 24/27 : COPY --from=golang /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ---> Using cache
 ---> b4dbd26dec0b
Step 25/27 : COPY --from=golang --chown=app:app /scratch-tmp /tmp
 ---> Using cache
 ---> a6959de22414
Step 26/27 : COPY --from=golang /go/src/github.com/openfaas/nats-queue-worker/app    .
 ---> b4ee64cb047c
Step 27/27 : CMD ["./app"]
 ---> Running in 7ae8bb6be5d3
Removing intermediate container 7ae8bb6be5d3
 ---> fdb55c62cf8a
Successfully built fdb55c62cf8a                      
Successfully tagged openfaas/queue-worker:latest-armhf
```
2. Run the app 
```
$ docker run openfaas/queue-worker:latest-armhf
Starting Queue worker.
Version: 0.10.1
Git Commit: 1f4e16e1f7afe1fbd464fcaa8a7dabaa3e4ef0bb
Connect: nats://nats:4222
can't connect to nats://nats:4222: nats: no servers available for connection
panic: can't connect to nats://nats:4222: nats: no servers available for connection
goroutine 1 [running]:
log.Panic(0x85beac, 0x1, 0x1)
        /usr/local/go/src/log/log.go:338 +0x84
main.main()
        /go/src/github.com/openfaas/nats-queue-worker/main.go:219 +0x4d8
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
