### PR TITLE
redact request data from routine logging

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -82,3 +82,15 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvokeOff_UsesDirectInvocation(t 
 		t.Errorf("want %s, got %s", wantURL, fnURL)
 	}
 }
+
+func Test_redact(t *testing.T) {
+
+	m := &stan.Msg{
+		Data: []byte(`to-be-redacted-in-logs`)
+	}
+	want:= []byte(`xxxxxx`)
+	got := redact(m)
+	if !bytes.Equal(got.Data,want) {
+		t.Errorf("want %s, got %s", want, got.Data)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
+	stan "github.com/nats-io/stan.go"
+	"github.com/nats-io/stan.go/pb"
 	"github.com/openfaas/faas/gateway/queue"
 )
 
@@ -86,11 +89,18 @@ func Test_makeFunctionURL_DefaultPathQS_GatewayInvokeOff_UsesDirectInvocation(t 
 func Test_redact(t *testing.T) {
 
 	m := &stan.Msg{
-		Data: []byte(`to-be-redacted-in-logs`)
+		MsgProto: pb.MsgProto{
+			Data: []byte(`to-be-redacted-in-logs`),
+		},
 	}
-	want:= []byte(`xxxxxx`)
+	want := &stan.Msg{
+		MsgProto: pb.MsgProto{
+			Data: []byte(`xxxxxx`),
+		},
+	}
 	got := redact(m)
-	if !bytes.Equal(got.Data,want) {
-		t.Errorf("want %s, got %s", want, got.Data)
+
+	if strings.Compare(got, want.String()) != 0 {
+		t.Errorf("want %s, got %s", want, got)
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR redacts logging incoming request data as part of the routine logging.

## Description
<!--- Describe your changes in detail -->

For cases where ```DebugPrintBody ``` is not set to true, the request data will be redacted and will be shown as `xxxxxx`. User can print the request data by setting DebugPrintBody to true via env variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/nats-queue-worker/issues/107)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit test. Adopted the approach used in std lib: https://golang.org/src/net/url/url.go?s=25219:25250#L852. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
