### PR TITLE
Fix basic auth for async report

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func main() {
 			}
 
 			if config.GatewayInvoke == false {
-				statusCode, reportErr := postReport(&client, req.Function, status, timeTaken, config.GatewayAddressURL(), credentials)
+				statusCode, reportErr := postReport(&client, req.Function, status, timeTaken, &config, credentials)
 				if reportErr != nil {
 					log.Printf("[#%d] Error posting report: %s\n", i, reportErr)
 				} else {
@@ -179,7 +179,7 @@ func main() {
 		}
 
 		if config.GatewayInvoke == false {
-			statusCode, reportErr := postReport(&client, req.Function, res.StatusCode, timeTaken, config.GatewayAddressURL(), credentials)
+			statusCode, reportErr := postReport(&client, req.Function, res.StatusCode, timeTaken, &config, credentials)
 			if reportErr != nil {
 				log.Printf("[#%d] Error posting report: %s\n", i, reportErr.Error())
 			} else {
@@ -304,18 +304,18 @@ func copyHeaders(destination http.Header, source *http.Header) {
 	}
 }
 
-func postReport(client *http.Client, function string, statusCode int, timeTaken float64, gatewayAddress string, credentials *auth.BasicAuthCredentials) (int, error) {
+func postReport(client *http.Client, function string, statusCode int, timeTaken float64, config *QueueWorkerConfig, credentials *auth.BasicAuthCredentials) (int, error) {
 	req := AsyncReport{
 		FunctionName: function,
 		StatusCode:   statusCode,
 		TimeTaken:    timeTaken,
 	}
 
-	targetPostback := fmt.Sprintf("http://%s/system/async-report", gatewayAddress)
+	targetPostback := fmt.Sprintf("http://%s/system/async-report", config.GatewayAddressURL())
 	reqBytes, _ := json.Marshal(req)
 	request, err := http.NewRequest(http.MethodPost, targetPostback, bytes.NewReader(reqBytes))
 
-	if os.Getenv("basic_auth") == "true" && credentials != nil {
+	if config.BasicAuth && credentials != nil {
 		request.SetBasicAuth(credentials.User, credentials.Password)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Solves edge case where basic auth fails for function statistics post back to
the gateway when the basic_auth env variable is set to “1”.

## Description
<!--- Describe your changes in detail -->
Use config.BasicAuth instead of checking the env_var in the postReport function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#116 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed openfaas using kind and arkade.
Updated the queue-worker deployment.
```
kubectl edit deploy/queue-worker -n openfaas
```
changes:
```yaml
template:
  spec:
    containers:
    - env:
      - name: gateway_invoke
        value: "false"
      - name: basic_auth
        value: "1"
      image: welteki/queue-worker:async-report
```
Deployed figlet from the store and invoked it async.
Logs for the queue-worker:
```
[#1] Received on [faas-request]: 'sequence:1 subject:"faas-request" data:"{\"Header\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"6\"],\"Content-Type\":[\"text/plain\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Call-Id\":[\"9a9c9817-6436-47a3-8329-40023db9a14e\"],\"X-Start-Time\":[\"1643187927333584634\"]},\"Host\":\"127.0.0.1:8080\",\"Body\":\"YXN5bmMK\",\"Method\":\"POST\",\"Path\":\"\",\"QueryString\":\"\",\"Function\":\"figlet\",\"QueueName\":\"\",\"CallbackUrl\":null}" timestamp:1643187927345634173 '
[#1] Invoking: figlet with 6 bytes, via: http://figlet.openfaas-fn.svc.cluster.local:8080/
[#1] Invoked: figlet [200] in 0.198375s
[#1] figlet returned 174 bytes
[#1] Posting report for figlet, status: 202
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
